### PR TITLE
Add Quota usage

### DIFF
--- a/src/Classes/SubscriptionService.php
+++ b/src/Classes/SubscriptionService.php
@@ -138,6 +138,20 @@ class SubscriptionService
     $this->updateSetting('quota', $response['quota']);
   }
 
+  public function getUsage($page = 1)
+  {
+    $response = $this->apiRequest(
+      'usage',
+      ['page' => $page]
+    );
+
+    if ($response['error']) {
+      throw new Exception($response['message']);
+    }
+
+    return $response;
+  }
+
   public function getQuota($refreshQuota = false)
   {
     if ($refreshQuota) {

--- a/version.xml
+++ b/version.xml
@@ -5,8 +5,8 @@
 <version>
 	<application>ojtPlugin</application>
 	<type>plugins.generic</type>
-	<release>2.1.0.0</release>
-	<date>2025-05-24</date>
+	<release>2.1.2.0</release>
+	<date>2025-09-25</date>
 	<lazy-load>0</lazy-load>
 	<class>OjtPlugin</class>
 </version>


### PR DESCRIPTION
This pull request introduces a new method for retrieving usage information from the subscription API and updates the plugin version to reflect this enhancement.

**Feature Addition:**

* Added a new `getUsage($page = 1)` method to `SubscriptionService`, allowing retrieval of paginated usage data from the API, with error handling for API response failures.

**Version Update:**

* Updated `version.xml` to increment the plugin version from `2.1.1.2` to `2.1.2.0` and changed the release date to `2025-09-25` to reflect the new feature.