### PR TITLE
feat: add getUsage method to SubscriptionService for API usage tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.1.0.1 : 03 Oct 2025
+- Add getUsage method for usage tracking
+
 ### 3.1.0.0 : 06 Sep 2025
 - Compatibility with OJS 3.5.x.x
 - Improved Plugin Installed UI with action column and documentation link (based on plugin metadata)

--- a/classes/SubscriptionService.php
+++ b/classes/SubscriptionService.php
@@ -40,6 +40,20 @@ class SubscriptionService
     throw new Exception('Unknown subscription mode');
   }
 
+  public function getUsage($page = 1)
+  {
+    $response = $this->apiRequest(
+      'usage',
+      ['page' => $page]
+    );
+
+    if ($response['error']) {
+      throw new Exception($response['message']);
+    }
+
+    return $response;
+  }
+
   public function getSubscriptionApi($method = '')
   {
     return OjtControlPanelPlugin::SERVICE_API . 'api/v2/subscription/' . $method;

--- a/version.xml
+++ b/version.xml
@@ -5,8 +5,8 @@
 <version>
 	<application>ojtControlPanel</application>
 	<type>plugins.generic</type>
-	<release>3.1.0.0</release>
-	<date>2025-09-06</date>
+	<release>3.1.0.1</release>
+	<date>2025-10-03</date>
 	<lazy-load>0</lazy-load>
 	<class>OjtControlPanelPlugin</class>
 </version>


### PR DESCRIPTION
This pull request introduces a new method for retrieving usage data from the subscription service API and updates the plugin version to reflect this change.

API Enhancements:

* Added a new `getUsage($page = 1)` method in `SubscriptionService.php` to fetch usage data from the API, including error handling for API response errors.

Version Update:

* Updated `version.xml` to increment the plugin release version to `3.1.0.1` and changed the release date to `2025-10-03`.