### PR TITLE
feat(ojtPlugin): introduce shared jobs ecosystem for OJT Plugins - OJS 33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 2.2.0.0 : 30 March 2026
+- Added jobs ecosystem for OJT plugins (register, dispatch, and process background jobs)
+- Optimized `OjtPlugin` by separating core logic into dedicated services
+- Improved worker and queue handling stability
+
 ### 2.1.3.2 : 12 Jan 2026
 - Add Feature force report to service panel for plugin registered
 

--- a/Jobs.inc.php
+++ b/Jobs.inc.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * Shared job registry for OJT plugins.
+ *
+ * Usage:
+ * import('plugins.generic.ojtPlugin.Jobs');
+ * OjtJobs::register($plugin, [new MyJob($plugin)]);
+ * OjtJobs::dispatch($plugin, 'myJob.type', $payload, $options);
+ */
+class OjtJobs
+{
+    /** @var bool */
+    protected static $hookRegistered = false;
+
+    /** @var array<string,object> */
+    protected static $plugins = [];
+
+    /** @var array<string,array<string,object>> */
+    protected static $jobsByPlugin = [];
+
+    /** @var array<string,object[]> */
+    protected static $jobsByType = [];
+
+    /**
+     * Register jobs for a plugin instance.
+     *
+     * @param object $plugin
+     * @param array $jobs
+     * @return bool
+     */
+    public static function register($plugin, array $jobs = [])
+    {
+        $key = spl_object_hash($plugin);
+        if (!isset(self::$plugins[$key])) {
+            self::$plugins[$key] = $plugin;
+            self::$jobsByPlugin[$key] = [];
+        }
+
+        foreach ($jobs as $job) {
+            self::registerJob($plugin, $job);
+        }
+
+        if (!self::$hookRegistered) {
+            HookRegistry::register('OjtPlugin::processJob', [__CLASS__, 'handleProcessJob']);
+            self::$hookRegistered = true;
+        }
+
+        return true;
+    }
+
+    /**
+     * Register a single job for a plugin instance.
+     *
+     * @param object $plugin
+     * @param object $job
+     * @return void
+     */
+    public static function registerJob($plugin, $job)
+    {
+        if (!$job || !method_exists($job, 'getType')) {
+            return;
+        }
+
+        $key = spl_object_hash($plugin);
+        if (!isset(self::$plugins[$key])) {
+            self::$plugins[$key] = $plugin;
+            self::$jobsByPlugin[$key] = [];
+        }
+
+        $type = (string) $job->getType();
+        if ($type === '') {
+            return;
+        }
+
+        self::$jobsByPlugin[$key][$type] = $job;
+        if (!isset(self::$jobsByType[$type])) {
+            self::$jobsByType[$type] = [];
+        }
+        self::$jobsByType[$type][] = $job;
+    }
+
+    /**
+     * Dispatch one background job.
+     *
+     * @param object $plugin
+     * @param string $jobType
+     * @param array $payload
+     * @param array $options
+     * @return mixed|null
+     */
+    public static function dispatch($plugin, $jobType, array $payload = [], array $options = [])
+    {
+        $job = self::resolveJob($plugin, $jobType);
+        if (!$job) {
+            error_log('OjtJobs: no registered job handler for type "' . $jobType . '".');
+            return null;
+        }
+
+        if (!method_exists($job, 'dispatch')) {
+            error_log('OjtJobs: job handler missing dispatch() for type "' . $jobType . '".');
+            return null;
+        }
+
+        return $job->dispatch($payload, $options);
+    }
+
+    /**
+     * WorkerBee process callback.
+     */
+    public static function handleProcessJob($hookName, $args)
+    {
+        $jobType = &$args[0];
+        $payload = &$args[1];
+        $handled = &$args[2];
+        $result = &$args[3];
+        $data = isset($args[5]) && is_array($args[5]) ? $args[5] : [];
+
+        if (empty(self::$jobsByType[$jobType])) {
+            return false;
+        }
+
+        foreach (self::$jobsByType[$jobType] as $job) {
+            if (!method_exists($job, 'handle')) {
+                continue;
+            }
+            $result = $job->handle(is_array($payload) ? $payload : [], $data);
+            $handled = true;
+            return false;
+        }
+
+        return false;
+    }
+
+    protected static function resolveJob($plugin, $jobType)
+    {
+        $key = spl_object_hash($plugin);
+        if (!isset(self::$plugins[$key])) {
+            // Plugin must call register() first with its jobs list.
+            return null;
+        }
+
+        if (empty(self::$jobsByPlugin[$key])) {
+            return null;
+        }
+
+        return self::$jobsByPlugin[$key][$jobType] ?? null;
+    }
+}

--- a/OjtPageHandler.inc.php
+++ b/OjtPageHandler.inc.php
@@ -312,7 +312,7 @@ class OjtPageHandler extends Handler
         try {
             $response = $this->ojtPlugin->getHttpClient()->get($url, $params);
 
-            $pluginSettingsDao = DAORegistry::getDAO('PluginSettingsDAO');
+            $pluginSettingsDao = DAORegistry::getDAO('PluginSettingsDAO'); /** @var \PluginSettingsDAO $pluginSettingsDao */
             $ojtplugin = $this->ojtPlugin;
             $pluginGenericPath = 'plugins' . DIRECTORY_SEPARATOR . 'generic' . DIRECTORY_SEPARATOR;
             $plugins = array_map(function ($plugin) use ($ojtplugin, $pluginSettingsDao, $pluginGenericPath) {
@@ -419,7 +419,7 @@ class OjtPageHandler extends Handler
         $pluginClassName = $request->getUserVar('className');
         $isEnabled       = ($request->getUserVar('enabled') == 'true') ? true : false;
 
-        $targetPlugin = PluginRegistry::getPlugin($pluginType, $pluginClassName);
+        $targetPlugin = PluginRegistry::getPlugin($pluginType, $pluginClassName); /** @var \LazyLoadPlugin $targetPlugin */
 
         if (!$targetPlugin && !is_object($targetPlugin)) {
             $json['error'] = 1;

--- a/OjtPlugin.inc.php
+++ b/OjtPlugin.inc.php
@@ -6,13 +6,13 @@ import('plugins.generic.ojtPlugin.helpers.OJTHelper');
 use Openjournalteam\OjtPlugin\Classes\ApiServicePanel;
 use Openjournalteam\OjtPlugin\Classes\ParamHandler;
 use Openjournalteam\OjtPlugin\Classes\DiscordNotifier;
+use Openjournalteam\OjtPlugin\Migrations\MigrationManager;
 use Openjournalteam\OjtPlugin\Services\JobQueueService;
 use Openjournalteam\OjtPlugin\Services\HookService;
 use Openjournalteam\OjtPlugin\Services\InstallerService;
 use Openjournalteam\OjtPlugin\Services\LoggingService;
 use Openjournalteam\OjtPlugin\Services\ModulesService;
 use Openjournalteam\OjtPlugin\Traits\HasIndexing;
-use VersionDAO;
 
 class OjtPlugin extends \GenericPlugin
 {
@@ -34,13 +34,13 @@ class OjtPlugin extends \GenericPlugin
             if ($this->getEnabled()) {
                 // register_shutdown_function([$this, 'fatalHandler']);
                 $this->init();
+                MigrationManager::make($this)->runMigrations();
                 $this->jobQueueService();
                 $this->loggingService()->setLogger();
                 $this->modulesService()->createModulesFolder();
                 $this->modulesService()->registerModules();
                 $this->hookService()->registerHooks();
             }
-
 
             return true;
         }
@@ -367,10 +367,6 @@ class OjtPlugin extends \GenericPlugin
         return $this->hookService()->settingsWebsite($hookName, $args);
     }
 
-    public function addIndexingPage($hookName, $args)
-    {
-        return $this->hookService()->addIndexingPage($hookName, $args);
-    }
 
     public function getModulesPath($path = '')
     {

--- a/OjtPlugin.inc.php
+++ b/OjtPlugin.inc.php
@@ -3,25 +3,27 @@
 import('lib.pkp.classes.plugins.GenericPlugin');
 import('plugins.generic.ojtPlugin.helpers.OJTHelper');
 
-use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\GuzzleException;
-use Monolog\Handler\StreamHandler;
-use Monolog\Logger;
-use Monolog\Utils;
 use Openjournalteam\OjtPlugin\Classes\ApiServicePanel;
-use Openjournalteam\OjtPlugin\Classes\ErrorHandler;
 use Openjournalteam\OjtPlugin\Classes\ParamHandler;
-use Openjournalteam\OjtPlugin\Classes\ServiceHandler;
-use Openjournalteam\OjtPlugin\Classes\IndexingPageHandler;
 use Openjournalteam\OjtPlugin\Classes\DiscordNotifier;
+use Openjournalteam\OjtPlugin\Services\JobQueueService;
+use Openjournalteam\OjtPlugin\Services\HookService;
+use Openjournalteam\OjtPlugin\Services\InstallerService;
+use Openjournalteam\OjtPlugin\Services\LoggingService;
+use Openjournalteam\OjtPlugin\Services\ModulesService;
 use Openjournalteam\OjtPlugin\Traits\HasIndexing;
-use Psr\Log\LogLevel;
+use VersionDAO;
 
-class OjtPlugin extends GenericPlugin
+class OjtPlugin extends \GenericPlugin
 {
     use HasIndexing;
 
     public $registeredModule;
+    private ?HookService $hookService = null;
+    private ?InstallerService $installerService = null;
+    private ?LoggingService $loggingService = null;
+    private ?ModulesService $modulesService = null;
+    private ?JobQueueService $jobQueueService = null;
 
     const API = "https://openjournaltheme.com/index.php/wp-json/openjournalvalidation/v3";
     const SERVICE_API = "https://sp.openjournaltheme.com/";
@@ -30,17 +32,13 @@ class OjtPlugin extends GenericPlugin
     {
         if (parent::register($category, $path, $mainContextId)) {
             if ($this->getEnabled()) {
-                register_shutdown_function([$this, 'fatalHandler']);
+                // register_shutdown_function([$this, 'fatalHandler']);
                 $this->init();
-                $this->setLogger();
-                $this->createModulesFolder();
-                $this->registerModules();
-                // HookRegistry::register('Template::Settings::website', array($this, 'settingsWebsite'));
-                HookRegistry::register('LoadHandler', [$this, 'setPageHandler']);
-                HookRegistry::register('TemplateManager::setupBackendPage', [$this, 'setupBackendPage']);
-                HookRegistry::register('TemplateManager::display', [$this, 'fixThemeNotLoadedOnFrontend']);
-                // HookRegistry::register('TemplateManager::display', [$this, 'addHeader']);
-                HookRegistry::register('SitemapHandler::createJournalSitemap', [$this, 'addIndexingPage']);
+                $this->jobQueueService();
+                $this->loggingService()->setLogger();
+                $this->modulesService()->createModulesFolder();
+                $this->modulesService()->registerModules();
+                $this->hookService()->registerHooks();
             }
 
 
@@ -68,6 +66,46 @@ class OjtPlugin extends GenericPlugin
         $discordNotifier->notifyPluginError($pluginFolder, $data);
     }
 
+    private function hookService(): HookService
+    {
+        if ($this->hookService === null) {
+            $this->hookService = new HookService($this);
+        }
+        return $this->hookService;
+    }
+
+    private function installerService(): InstallerService
+    {
+        if ($this->installerService === null) {
+            $this->installerService = new InstallerService($this);
+        }
+        return $this->installerService;
+    }
+
+    private function loggingService(): LoggingService
+    {
+        if ($this->loggingService === null) {
+            $this->loggingService = new LoggingService($this);
+        }
+        return $this->loggingService;
+    }
+
+    private function modulesService(): ModulesService
+    {
+        if ($this->modulesService === null) {
+            $this->modulesService = new ModulesService($this);
+        }
+        return $this->modulesService;
+    }
+
+    public function jobQueueService(): JobQueueService
+    {
+        if ($this->jobQueueService === null) {
+            $this->jobQueueService = new JobQueueService($this);
+        }
+        return $this->jobQueueService;
+    }
+
     /**
      * Determine whether the plugin can be enabled.
      * @return boolean
@@ -77,9 +115,6 @@ class OjtPlugin extends GenericPlugin
         return $this->getCanDisable();
     }
 
-    /**
-     * @copydoc Plugin::getCanDisable()
-     */
     function getCanDisable()
     {
         if ($this->isCurrentUserAreJournalManager()) return true;
@@ -95,7 +130,7 @@ class OjtPlugin extends GenericPlugin
         $currentUser = $this->getRequest()->getUser();
         if (!$currentUser) return false;
 
-        $userGroupDao = DAORegistry::getDAO('UserGroupDAO');
+        $userGroupDao = \DAORegistry::getDAO('UserGroupDAO'); /** @var \UserGroupDAO $userGroupDao */
         $currentUserGroups = $userGroupDao->getByUserId($currentUser->getId(), $this->getCurrentContextId());
 
         $currentUserGroupNameLocaleKeys = collect($currentUserGroups->toArray())->map(function ($userGroup) {
@@ -114,29 +149,16 @@ class OjtPlugin extends GenericPlugin
 
     public static function get()
     {
-        $plugin = PluginRegistry::getPlugin('generic', 'ojtPlugin');
+        $plugin = \PluginRegistry::getPlugin('generic', 'ojtPlugin');
         if (!$plugin) return new static();
 
         return $plugin;
     }
 
-    public function isAllowSendLog($hour = 4)
-    {
-        $now = time();
-        $lastSendLogTime = $this->getSetting(CONTEXT_SITE, 'lastSendLogTime');
-        if ($lastSendLogTime === null) {
-            return true;
-        }
-
-        $diff = $now - $lastSendLogTime;
-        $diffInHour = round($diff / (60 * 60));
-        return $diffInHour >= $hour;
-    }
-
     public function getHttpClient($headers = [])
     {
 
-        $versionDao = DAORegistry::getDAO('VersionDAO');
+        $versionDao = \DAORegistry::getDAO('VersionDAO'); /** @var \VersionDAO $versionDao */
         $version    = $versionDao->getCurrentVersion();
         $agents = [
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:7.0.1) Gecko/20100101 Firefox/7.0.1',
@@ -161,6 +183,27 @@ class OjtPlugin extends GenericPlugin
             'timeout' => 60,
             'headers' => $headers
         ]);
+    }
+
+    public static function dispatch($jobType, $payload = [], $options = [])
+    {
+        $plugin = self::get();
+        if (!$plugin) {
+            error_log('OjtWorkerBee dispatch skipped: plugin instance not found.');
+            return null;
+        }
+
+        if (!$plugin->isEnabledForRuntime()) {
+            error_log('OjtWorkerBee dispatch skipped: plugin is not enabled for runtime.');
+            return null;
+        }
+
+        $jobId = $plugin->jobQueueService()->dispatch($jobType, $payload, $options);
+        if (!$jobId) {
+            error_log('OjtWorkerBee dispatch returned empty job id for type "' . (string) $jobType . '".');
+        }
+
+        return $jobId;
     }
 
     /**
@@ -188,7 +231,7 @@ class OjtPlugin extends GenericPlugin
 
         $data['error'] = $error;
 
-        if ($this->str_contains($error['file'], 'ojtPlugin')) {
+        if (ojt_str_contains($error['file'], 'ojtPlugin')) {
             $folders = explode('/', $error['file']);
             $key = array_search('modules', $folders);
             if (is_int($key)) {
@@ -196,7 +239,7 @@ class OjtPlugin extends GenericPlugin
                 $path = __DIR__ . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . $errorPluginFolder;
                 $plugin = include($path . DIRECTORY_SEPARATOR . 'index.php');
                 $isRemoveAllowed = true;
-                if (!$plugin && $plugin instanceof Plugin) return;
+                if (!$plugin && $plugin instanceof \Plugin) return;
 
                 // check if plugin can be deleted
                 if (method_exists($plugin, 'getCanDelete')) {
@@ -210,7 +253,7 @@ class OjtPlugin extends GenericPlugin
                             return;
                         }
 
-                        $this->recursiveDelete($path);
+                        $this->installerService()->recursiveDelete($path);
                         $this->sendDiscordNotification($errorPluginFolder, $data);
                     } catch (\Throwable $th) {
                         $data['error_type'] = 'pluginRemoveError';
@@ -235,7 +278,7 @@ class OjtPlugin extends GenericPlugin
         }
 
         foreach($standalonePlugins as $genericPlugin) {
-            if ($this->str_contains($error['file'], $genericPlugin['name'])) {
+            if (ojt_str_contains($error['file'], $genericPlugin['name'])) {
                 $folders = explode('/', $error['file']);
                 $key = array_search('generic', $folders);
 
@@ -244,7 +287,7 @@ class OjtPlugin extends GenericPlugin
                     $plugin = include($path . DIRECTORY_SEPARATOR . 'index.php');
 
                     $isRemoveAllowed = true;
-                    if (!$plugin && $plugin instanceof Plugin) return;
+                    if (!$plugin && $plugin instanceof \Plugin) return;
 
                     // check if plugin can be deleted
                     if (method_exists($plugin, 'getCanDelete')) {
@@ -258,7 +301,7 @@ class OjtPlugin extends GenericPlugin
                                 return;
                             }
 
-                            $this->recursiveDelete($path);
+                            $this->installerService()->recursiveDelete($path);
 
                             $this->sendDiscordNotification($genericPlugin['name'], $data);
                         } catch (\Throwable $th) {
@@ -284,228 +327,182 @@ class OjtPlugin extends GenericPlugin
         }
     }
 
-    public static function getErrorLogFile()
+    public function flushCache()
     {
-        return Config::getVar('files', 'files_dir') . DIRECTORY_SEPARATOR . 'ojtPlugin' . DIRECTORY_SEPARATOR . 'error.log';
+        $templateMgr = \TemplateManager::getManager($this->getRequest());
+        $templateMgr->clearTemplateCache();
+        $templateMgr->clearCssCache();
+
+        $cacheMgr = \CacheManager::getManager();
+        $cacheMgr->flush();
     }
 
-    public static function deleteLogFile(): bool
+    public function registerHooks(): void
     {
-        $errorLogFile = static::getErrorLogFile();
-        if (!is_file($errorLogFile)) return false;
-
-
-        return unlink($errorLogFile);
-    }
-
-    public function isTimeToDeleteLog($days = 2)
-    {
-        $errorLogFile = static::getErrorLogFile();
-
-        if (!is_file($errorLogFile)) return false;
-
-        $dateCreatedFile = filemtime($errorLogFile);
-
-        $now = time();
-        $datediff = $now - $dateCreatedFile;
-        $diffInDays = round($datediff / (60 * 60 * 24));
-
-        return $diffInDays > $days;
-    }
-
-    public function setLogger()
-    {
-        // Jangan simpan log error ketika setting ini didisable
-        if (!$this->isDiagnosticEnabled()) return;
-
-        $logger = new Logger('OJTLog');
-        $logger->pushHandler(new ServiceHandler(Logger::ERROR));
-        $logger->pushHandler(new StreamHandler(static::getErrorLogFile(), Logger::ERROR));
-
-        set_exception_handler(function (Throwable $e) use ($logger): void {
-            if ($this->isTimeToDeleteLog()) {
-                static::deleteLogFile();
-            };
-
-            if ($this->str_contains($e->getFile(), 'ojtPlugin')) {
-                $logger->log(
-                    LogLevel::ERROR,
-                    sprintf('Uncaught Exception %s: "%s" at %s line %s', Utils::getClass($e), $e->getMessage(), $e->getFile(), $e->getLine()),
-                    ['exception' => $e]
-                );
-            }
-
-            throw $e;
-        });
-
-        set_error_handler(function (int $code, string $message, string $file = '', int $line = 0, ?array $context = []) use ($logger): bool {
-            if ($code !== E_ERROR) return false;
-
-            if ($this->isTimeToDeleteLog()) {
-                static::deleteLogFile();
-            };
-
-
-            $logger->log(LogLevel::CRITICAL, 'E_ERROR: ' . $message, ['code' => $code, 'message' => $message, 'file' => $file, 'line' => $line]);
-            return false;
-        });
+        $this->hookService()->registerHooks();
     }
 
     public function fixThemeNotLoadedOnFrontend($hookName, $args)
     {
-        $templateMgr            = $args[0];
-        if ($this->getJournalVersion() != '31') {
-            if ($templateMgr->getTemplateVars('activeTheme')) return;
-        }
-
-        $allThemes = PluginRegistry::loadCategory('themes', true);
-        $activeTheme = null;
-        $context = $this->getCurrentContextId() ? $this->getRequest()->getContext() : $this->getRequest()->getSite();
-        $themePluginPath = $context->getData('themePluginPath');
-
-        foreach ($allThemes as $theme) {
-            if ($themePluginPath === basename($theme->pluginPath) && $theme->getEnabled()) {
-                $activeTheme = $theme;
-                break;
-            }
-        }
-
-        $templateMgr->assign('activeTheme', $activeTheme);
+        return $this->hookService()->fixThemeNotLoadedOnFrontend($hookName, $args);
     }
 
-    function addHeader($hookName, $args)
+    public function addHeader($hookName, $args)
     {
-        $templateMgr            = &$args[0];
-
-        $templateMgr->addHeader(
-            'ojtcontrolpanel',
-            '<meta name="ojtcontrolpanel" content="OJT Control Panel Version ' . $this->getPluginVersion() . ' by openjournaltheme.com">',
-            [
-                'contexts' => ['frontend'],
-            ]
-        );
-    }
-
-
-    public function flushCache()
-    {
-        $templateMgr = TemplateManager::getManager($this->getRequest());
-        $templateMgr->clearTemplateCache();
-        $templateMgr->clearCssCache();
-
-        $cacheMgr = CacheManager::getManager();
-        $cacheMgr->flush();
+        return $this->hookService()->addHeader($hookName, $args);
     }
 
     public function setupBackendPage($hookName, $args)
     {
-        $request = $this->getRequest();
+        return $this->hookService()->setupBackendPage($hookName, $args);
+    }
 
-        if (!$request->getContext()) return;
+    public function setPageHandler($hookName, $params)
+    {
+        return $this->hookService()->setPageHandler($hookName, $params);
+    }
 
-        $templateMgr    = TemplateManager::getManager($this->getRequest());
-        $router         = $request->getRouter();
-        $userRoles      = (array) $router->getHandler()->getAuthorizedContextObject(ASSOC_TYPE_USER_ROLES);
-        $user           = $request->getUser();
+    public function settingsWebsite($hookName, $args)
+    {
+        return $this->hookService()->settingsWebsite($hookName, $args);
+    }
 
-        if (!$user || !count(array_intersect([ROLE_ID_MANAGER, ROLE_ID_SITE_ADMIN], $userRoles))) return;
-
-        $menu = $templateMgr->getState('menu');
-        $menu['ojtPlugin'] = [
-            'name' => 'OJT Control Panel',
-            'url' => $request->getDispatcher()->url($request, ROUTE_PAGE, $request->getContext()->getPath(), 'ojt') . '?PageSpeed=off',
-            "isCurrent" => false
-        ];
-
-
-        if ($this->getSetting($this->getCurrentContextId(), 'show_support_link_ojs') ?? true) {
-            $menu['ojtSupportTicketing'] = [
-                'name' => 'Get OJT support',
-                'url' => $request->getDispatcher()->url($request, ROUTE_PAGE, $request->getContext()->getPath(), 'ojt', 'support'),
-                "isCurrent" => false
-            ];
-        }
-
-        $templateMgr->setState(['menu' => $menu]);
+    public function addIndexingPage($hookName, $args)
+    {
+        return $this->hookService()->addIndexingPage($hookName, $args);
     }
 
     public function getModulesPath($path = '')
     {
-        return $this->getPluginPath() . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . $path;
+        return $this->modulesService()->getModulesPath($path);
+    }
+
+    public function createModulesFolder()
+    {
+        return $this->modulesService()->createModulesFolder();
     }
 
     public function registerModules()
     {
-        $modulesFolder = $this->getDirs($this->getModulesPath());
-
-        import('lib.pkp.classes.site.VersionCheck');
-
-        $plugins = [];
-        $fileManager = new FileManager();
-        foreach ($modulesFolder as $key => $moduleFolder) {
-            $versionFile = $this->getModulesPath($moduleFolder  . DIRECTORY_SEPARATOR . "version.xml");
-            $indexFile = $this->getModulesPath(DIRECTORY_SEPARATOR . $moduleFolder . DIRECTORY_SEPARATOR . "index.php");
-            if (
-                !$fileManager->fileExists($versionFile) ||
-                !$fileManager->fileExists($indexFile)
-            ) {
-                continue;
-            }
-
-            $plugin         = include($indexFile);
-            if (!$plugin && $plugin instanceof Plugin) {
-                continue;
-            }
-
-            $version        = VersionCheck::getValidPluginVersionInfo($versionFile);
-
-            $categoryPlugin = explode('.', $version->getData('productType'))[1];
-            $categoryDir    = $this->getModulesPath();
-            $pluginDir = str_replace('\\', '/', $categoryDir .  $moduleFolder);
-
-            PluginRegistry::register($categoryPlugin, $plugin, $pluginDir);
-
-            if ($plugin instanceof ThemePlugin) {
-                $plugin->init();
-            }
-
-            $data                = $version->getAllData();
-            $data['version']     = $version->getVersionString();
-            $data['name']        = $plugin->getDisplayName();
-            $data['className']   = $plugin->getName();
-            $data['description'] = $plugin->getDescription();
-            $data['enabled']     = $plugin->getEnabled();
-
-            if (method_exists($plugin, 'getCanEnable') && !$plugin->getCanEnable()) {
-                $data['isAuthorized']   = $plugin->getCanEnable();
-            } else {
-                $data['isAuthorized']   = $this->getCanEnable();
-            }
-
-            $data['open']        = false;
-            $data['icon']        = method_exists($plugin, 'getPageIcon') ? $plugin->getPageIcon() : $this->getDefaultPluginIcon();
-            $data['documentation'] = method_exists($plugin, 'getDocumentation') ? $plugin->getDocumentation() : null;
-            $data['page']        = method_exists($plugin, 'getPage') ? $plugin->getPage() : null;
-            $data['sitemapData'] = method_exists($plugin, 'getSitemapData') ? $plugin->getSitemapData() : null;
-            $data['canDelete']   = method_exists($plugin, 'getCanDelete') ? $plugin->getCanDelete() : true;
-
-            $plugins[] = $data;
-        }
-        // HookRegistry::call('PluginRegistry::categoryLoaded::themes');
-
-
-        $this->registeredModule = $plugins;
-
-        return $plugins;
+        return $this->modulesService()->registerModules();
     }
 
     public function getRegisteredModules()
     {
-        if (!$this->registeredModule) {
-            return $this->registerModules();
+        return $this->modulesService()->getRegisteredModules();
+    }
+
+    public function getDirs($path, $recursive = false, array $filtered = [])
+    {
+        return $this->modulesService()->getDirs($path, $recursive, $filtered);
+    }
+
+    public function isAllowSendLog($hour = 4)
+    {
+        return $this->loggingService()->isAllowSendLog($hour);
+    }
+
+    public static function getErrorLogFile()
+    {
+        return static::$loggingService->getErrorLogFile();
+    }
+
+    public function deleteLogFile(): bool
+    {
+        return $this->loggingService()->deleteLogFile();
+    }
+
+    public function isTimeToDeleteLog($days = 2)
+    {
+        return $this->loggingService()->isTimeToDeleteLog($days);
+    }
+
+    public function setLogger()
+    {
+        return $this->loggingService()->setLogger();
+    }
+
+    public function isDiagnosticEnabled()
+    {
+        return $this->loggingService()->isDiagnosticEnabled();
+    }
+
+    public function updatePanel($url)
+    {
+        return $this->installerService()->updatePanel($url);
+    }
+
+    public function getPluginDownloadLink($pluginToken, $license = false, $journalUrl)
+    {
+        return $this->installerService()->getPluginDownloadLink($pluginToken, $license, $journalUrl);
+    }
+
+    public function installPlugin($url)
+    {
+        return $this->installerService()->installPlugin($url);
+    }
+
+    public function getStagingBasePath()
+    {
+        return $this->installerService()->getStagingBasePath();
+    }
+
+    public function installPluginToStaging($url)
+    {
+        return $this->installerService()->installPluginToStaging($url);
+    }
+
+    public function moveStagedPluginToFinal($stagingPath, $pluginFolder, $isSiteWide)
+    {
+        return $this->installerService()->moveStagedPluginToFinal($stagingPath, $pluginFolder, $isSiteWide);
+    }
+
+    public function instantiatePluginWithoutThrow($pluginFolder)
+    {
+        return $this->installerService()->instantiatePluginWithoutThrow($pluginFolder);
+    }
+
+    public function instantiatePluginFromGlobalDirectory($pluginFolder)
+    {
+        return $this->installerService()->instantiatePluginFromGlobalDirectory($pluginFolder);
+    }
+
+    public function cleanupOldStagingDirectories($hoursOld = 24)
+    {
+        return $this->installerService()->cleanupOldStagingDirectories($hoursOld);
+    }
+
+    public function uninstallPlugin($plugin)
+    {
+        return $this->installerService()->uninstallPlugin($plugin);
+    }
+
+    public function recursiveDelete($dirPath, $deleteParent = true)
+    {
+        return $this->installerService()->recursiveDelete($dirPath, $deleteParent);
+    }
+
+    public function isEnabledForRuntime()
+    {
+        if ($this->getEnabled()) {
+            return true;
         }
 
-        return $this->registeredModule;
+        $pluginName = strtolower_codesafe($this->getName());
+        $pluginSettingsDao = \DAORegistry::getDAO('PluginSettingsDAO');
+        $result = $pluginSettingsDao->retrieve(
+            'SELECT setting_value FROM plugin_settings WHERE plugin_name = ? AND setting_name = ? AND setting_value IN (?, ?, ?, ?) LIMIT 1',
+            [
+                $pluginName,
+                'enabled',
+                '1',
+                'true',
+                'on',
+                'yes',
+            ]
+        );
+
+        return (bool) $result->current();
     }
 
     public static function reportToServicePanel($plugin, $isGlobalPlugin = false, $params = [], $force = false)
@@ -558,61 +555,6 @@ d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 01
 </svg>';
     }
 
-    public function createModulesFolder()
-    {
-        if (is_dir(getcwd() . DIRECTORY_SEPARATOR . $this->getModulesPath())) {
-            return;
-        }
-
-        mkdir(getcwd() . DIRECTORY_SEPARATOR . $this->getModulesPath());
-    }
-
-    // Show available update on Setting -> Website
-    function settingsWebsite($hookName, $args)
-    {
-        if (!$this->getSetting(CONTEXT_SITE, 'isNewVersionAvailable')) {
-            return false;
-        }
-
-        $templateMgr = $args[1];
-        $output = &$args[2];
-
-        $output .= $templateMgr->fetch($this->getTemplateResource('backend/notif.tpl'));
-
-        // Permit other plugins to continue interacting with this hook
-        return false;
-    }
-
-    public function updatePanel($url)
-    {
-        // Check ziparchive extension
-        if (!class_exists('ZipArchive')) {
-            throw new Exception('Please Install PHP Zip Extension');
-        }
-
-        // Download file
-        $file_name = Config::getVar('files', 'files_dir') . DIRECTORY_SEPARATOR . 'OJTPanel.zip';
-        
-        $resource = \GuzzleHttp\Psr7\Utils::tryFopen($file_name, 'w');
-        $stream = \GuzzleHttp\Psr7\Utils::streamFor($resource);
-        $this->getHttpClient()->request('GET', $url, ['sink' => $stream]);
-
-        $zip = new ZipArchive;
-        if (!$zip->open($file_name)) {
-            unlink($file_name);
-            throw new Exception('Failed to Open Files plugin file');
-        }
-
-        $path    = 'plugins/generic';
-        if (!$zip->extractTo($path)) {
-            unlink($file_name);
-            throw new Exception('Failed to Extract Plugin,maybe because of folder permission.');
-        }
-        $zip->close();
-
-        unlink($file_name);
-    }
-
     /**
      * Install default settings on journal creation.
      * @return string
@@ -629,19 +571,12 @@ d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 01
         return $pluginPath . '/version.xml';
     }
 
-    /**
-     * Get the display name of this plugin.
-     * @return String
-     */
     public function getDisplayName()
     {
         return 'OJT Control Panel';
     }
 
-    /**
-     * @copydoc Plugin::getName()
-     */
-    function getName()
+    public function getName()
     {
         return 'ojtPlugin';
     }
@@ -654,20 +589,10 @@ d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 01
         return 'Control Panel Service Plugin From OpenJournalTheme.com';
     }
 
-    public function getPluginType()
-    {
-        import('lib.pkp.classes.site.VersionCheck');
-        $info = VersionCheck::getValidPluginVersionInfo($this->getPluginVersionFile());
-
-        return $info[1];
-    }
-
-
-
     public function getPluginVersion()
     {
         import('lib.pkp.classes.site.VersionCheck');
-        $version = VersionCheck::parseVersionXML($this->getPluginVersionFile());
+        $version = \VersionCheck::parseVersionXML($this->getPluginVersionFile());
         return $version['release'];
     }
 
@@ -685,71 +610,6 @@ d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 01
         }
 
         return $fullUrl;
-    }
-
-    public function setPageHandler($hookName, $params)
-    {
-        if ($this->getCurrentContextId() == 0) {
-            // Panel tidak support untuk sitewide
-            return false;
-        }
-
-        $page = $params[0];
-        $op   = &$params[1];
-
-        // Force http or https based on host
-        $request = Application::get()->getRequest();
-        $serverHost = $request->getServerHost(null, false);
-        $host = explode(':', (string) $serverHost)[0];
-        $shouldUseHttpProtocol = $this->shouldUseHttpProtocolForHost($host);
-        $request->_protocol = $shouldUseHttpProtocol ? 'http' : 'https';
-
-        if($page === 'ojt' && $op === 'api') {
-            define('HANDLER_CLASS', 'OjtPluginApiHandler');
-            $this->import('OjtPluginApiHandler');
-
-            return true;
-        }
-        
-        switch ($page) {
-            case 'ojt':
-                define('HANDLER_CLASS', 'OjtPageHandler');
-                $this->import('OjtPageHandler');
-
-                return true;
-                break;
-            case $this->getIndexingPagePath():
-                $enabledPlugins = $this->getEnabledPluginsSitemap();
-
-                // don't show page for plugins that is not enabled
-                // and don't have getSitemapData method in it
-                if (!$this->isAddSitemap($enabledPlugins[$op] ?? null)) {
-                    return false;
-                }
-
-                $plugin = $params[1];
-                $op = 'index';
-
-                define('HANDLER_CLASS', IndexingPageHandler::class);
-                IndexingPageHandler::setPlugin($this, $plugin);
-
-                return true;
-        }
-
-        return false;
-    }
-
-    private function shouldUseHttpProtocolForHost(string $host)
-    {
-        if (in_array($host, ['localhost', '127.0.0.1', '::1'], true)) {
-            return true;
-        }
-
-        if (preg_match('/^(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)/', $host)) {
-            return true;
-        }
-
-        return false;
     }
 
     /**
@@ -772,7 +632,7 @@ d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 01
         import('lib.pkp.classes.linkAction.request.OpenWindowAction');
         $linkAction = new LinkAction(
             'ojt_control_panel',
-            new OpenWindowAction($request->getDispatcher()->url($request, ROUTE_PAGE, $request->getContext()->getPath()) . '/ojt?PageSpeed=off'),
+            new \OpenWindowAction($request->getDispatcher()->url($request, ROUTE_PAGE, $request->getContext()->getPath()) . '/ojt?PageSpeed=off'),
             'Control Panel',
             null
         );
@@ -785,328 +645,15 @@ d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 01
         return $actions;
     }
 
-    /**
-     * Removing plugin folder
-     * @return bool - true if success.
-     */
-    public function uninstallPlugin($plugin)
-    {
-        $path = $this->getModulesPath($plugin->product);
-        if ($plugin->sitewide == true) {
-            $path = 'plugins' . DIRECTORY_SEPARATOR . 'generic' . DIRECTORY_SEPARATOR . $plugin->product;
-        }
-        try {
-            if (!is_dir($path)) {
-                throw new \Exception("$plugin->name not Found");
-            }
-            return $this->recursiveDelete($path);
-        } catch (\Throwable $th) {
-            $data['error'] = $th;
-            $data['error_type'] = 'pluginRemoveError';
-
-            // Send notification to discord about the deletion error in uninstallPlugin
-            // $this->sendDiscordNotification($plugin->name, $data);
-            
-            // Re-throw for proper error handling at caller level
-            throw $th;
-        }
-    }
-
-    public function recursiveDelete($dirPath, $deleteParent = true)
-    {
-        if (empty($dirPath) && !is_dir($dirPath)) {
-            return false;
-        }
-
-        $paths = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dirPath, FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::CHILD_FIRST);
-
-        foreach ($paths as $path) {
-            if (!$path->isWritable()) {
-                throw new \Exception("Can't remove plugins, please check folder permission for: " . $path->getPathname());
-            };
-        }
-        
-        foreach ($paths as $path) {
-            if ($path->isFile()) {
-                if (!unlink($path->getPathname())) {
-                    throw new \Exception("Failed to delete file: " . $path->getPathname());
-                }
-            } else {
-                if (!rmdir($path->getPathname())) {
-                    throw new \Exception("Failed to remove directory: " . $path->getPathname());
-                }
-            }
-        }
-        
-        if ($deleteParent) {
-            rmdir($dirPath);
-        }
-
-        return true;
-    }
-
     public function getJournalURL()
     {
         $request = $this->getRequest();
         return $request->getDispatcher()->url($request, ROUTE_PAGE, $request->getContext()->getPath());
     }
 
-    public function getPluginDownloadLink($pluginToken, $license = false, $journalUrl)
-    {
-        try {
-            $payload = [
-                'token' => $pluginToken,
-                'license' => $license,
-                'journal_url' => $journalUrl,
-                'ojs_version' => $this->getJournalVersion()
-            ];
-
-            $request = $this->getHttpClient(['Content-Type' => 'application/x-www-form-urlencoded',])
-                ->post(
-                    static::API . '/product/get_download_link',
-                    [
-                        'form_params' => $payload,
-                    ]
-                );
-
-            $response = json_decode((string) $request->getBody(), true);
-
-            if (isset($response['error']) && $response['error']) throw new Exception($response['msg']);
-
-            $result['product'] = $response['data']['download_link'];
-
-            $dependencies = [];
-            foreach ($response['data']['dependencies'] as $dependency) {
-                $data['link'] = $dependency['download_link'];
-                $data['folder'] = $dependency['folder'];
-                $dependencies[] = $data;
-            }
-
-            $result['dependencies'] = $dependencies;
-
-            return $result;
-        } catch (BadResponseException $e) {
-            throw $e;
-        } catch (Exception $e) {
-            throw $e;
-        }
-    }
-
-    /**
-     * Installing plugin to targeted folder.
-     * throw error if there is something wrong
-     * @return bool - true if success.
-     */
-    public function installPlugin($url)
-    {
-        $url = str_replace('https', 'http', $url);
-
-        // Download file
-        $file_name = Config::getVar('files', 'files_dir') . DIRECTORY_SEPARATOR . 'OJTTemporaryFile.zip';
-        $resource = \GuzzleHttp\Psr7\Utils::tryFopen($file_name, 'w');
-        $stream = \GuzzleHttp\Psr7\Utils::streamFor($resource);
-        $this->getHttpClient()->request('GET', $url, ['sink' => $stream]);
-        // Extract file
-        if (!class_exists('ZipArchive')) {
-            unlink($file_name);
-            throw new Exception('Please Install PHP Zip Extension');
-        }
-
-        $zip = new ZipArchive;
-        if (!$zip->open($file_name)) {
-            unlink($file_name);
-            throw new Exception('Failed to Open Files');
-        }
-
-        $path    = $this->getModulesPath();
-        if (!$zip->extractTo($path)) {
-            unlink($file_name);
-            throw new Exception('Failed to Extract Plugin, because of folder permission.');
-        }
-        $zip->close();
-
-        unlink($file_name);
-
-        return true;
-    }
-
-    /**
-     * Get the base path for staging directory
-     * @return string
-     */
-    public function getStagingBasePath()
-    {
-        return Config::getVar('files', 'files_dir') . DIRECTORY_SEPARATOR . 'ojt_staging';
-    }
-
-    /**
-     * Install plugin to staging directory first
-     * @param string $url Download URL for the plugin
-     * @return array ['stagingPath' => string, 'pluginFolder' => string]
-     * @throws Exception if installation fails
-     */
-    public function installPluginToStaging($url)
-    {
-        $url = str_replace('https', 'http', $url);
-
-        // Download file
-        $file_name = Config::getVar('files', 'files_dir') . DIRECTORY_SEPARATOR . 'OJTTemporaryFile_' . uniqid() . '.zip';
-        $resource = \GuzzleHttp\Psr7\Utils::tryFopen($file_name, 'w');
-        $stream = \GuzzleHttp\Psr7\Utils::streamFor($resource);
-        $this->getHttpClient()->request('GET', $url, ['sink' => $stream]);
-
-        // Extract file
-        if (!class_exists('ZipArchive')) {
-            unlink($file_name);
-            throw new Exception('Please Install PHP Zip Extension');
-        }
-
-        $zip = new ZipArchive;
-        if (!$zip->open($file_name)) {
-            unlink($file_name);
-            throw new Exception('Failed to Open Files');
-        }
-
-        // Create staging directory
-        $stagingBasePath = $this->getStagingBasePath();
-        if (!is_dir($stagingBasePath)) {
-            if (!mkdir($stagingBasePath, 0755, true)) {
-                unlink($file_name);
-                throw new Exception('Failed to create staging directory');
-            }
-        }
-
-        // Create unique staging path for this installation
-        $stagingPath = $stagingBasePath . DIRECTORY_SEPARATOR . 'staging_' . uniqid();
-        if (!mkdir($stagingPath, 0755, true)) {
-            unlink($file_name);
-            throw new Exception('Failed to create staging subdirectory');
-        }
-
-        if (!$zip->extractTo($stagingPath)) {
-            unlink($file_name);
-            $this->recursiveDelete($stagingPath);
-            throw new Exception('Failed to Extract Plugin to staging, because of folder permission.');
-        }
-
-        // Detect the plugin folder name from extracted contents
-        $extractedFolders = array_diff(scandir($stagingPath), ['.', '..']);
-        if (empty($extractedFolders)) {
-            unlink($file_name);
-            $this->recursiveDelete($stagingPath);
-            throw new Exception('No plugin folder found in extracted archive');
-        }
-
-        $pluginFolder = reset($extractedFolders);
-
-        $zip->close();
-        unlink($file_name);
-
-        return [
-            'stagingPath' => $stagingPath,
-            'pluginFolder' => $pluginFolder
-        ];
-    }
-
-    /**
-     * Move staged plugin to final destination
-     * @param string $stagingPath Path to staging directory
-     * @param string $pluginFolder Plugin folder name
-     * @param bool $isSiteWide Whether plugin is site-wide
-     * @throws Exception if move fails
-     */
-    public function moveStagedPluginToFinal($stagingPath, $pluginFolder, $isSiteWide)
-    {
-        $sourcePath = $stagingPath . DIRECTORY_SEPARATOR . $pluginFolder;
-
-        if ($isSiteWide) {
-            $destinationPath = getcwd() . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR . 'generic' . DIRECTORY_SEPARATOR . $pluginFolder;
-        } else {
-            $this->createModulesFolder();
-            $destinationPath = getcwd() . DIRECTORY_SEPARATOR . $this->getModulesPath($pluginFolder);
-        }
-
-        if (!is_dir($sourcePath)) {
-            throw new Exception("Source plugin directory not found in staging: {$sourcePath}");
-        }
-
-        // Remove existing destination if it exists
-        if (is_dir($destinationPath)) {
-            $this->recursiveDelete($destinationPath);
-        }
-
-        // Move the plugin directory
-        if (!rename($sourcePath, $destinationPath)) {
-            throw new Exception("Failed to move plugin from staging to final destination");
-        }
-
-        // Clean up the staging directory
-        if (is_dir($stagingPath) && count(array_diff(scandir($stagingPath), ['.', '..'])) === 0) {
-            rmdir($stagingPath);
-        }
-
-        $location = $isSiteWide ? 'plugins/generic/' : 'modules/';
-        error_log("Plugin '{$pluginFolder}' installed to {$location}");
-    }
-
-    /**
-     * Instantiate a plugin from the modules directory without throwing an exception
-     * @param string $pluginFolder Plugin folder name
-     * @return Plugin|false Plugin instance or false if not found
-     */
-    public function instantiatePluginWithoutThrow($pluginFolder)
-    {
-        $indexFile = $this->getModulesPath($pluginFolder . DIRECTORY_SEPARATOR . 'index.php');
-        if (!file_exists($indexFile)) {
-            return false;
-        }
-        return @include($indexFile);
-    }
-
-    /**
-     * Instantiate a plugin from the global plugins/generic directory
-     * @param string $pluginFolder Plugin folder name
-     * @return Plugin|false Plugin instance or false if not found
-     */
-    public function instantiatePluginFromGlobalDirectory($pluginFolder)
-    {
-        $indexFile = getcwd() . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR . 'generic' . DIRECTORY_SEPARATOR . $pluginFolder . DIRECTORY_SEPARATOR . 'index.php';
-        if (!file_exists($indexFile)) {
-            return false;
-        }
-        return @include($indexFile);
-    }
-
-    /**
-     * Clean up old staging directories
-     * @param int $hoursOld Delete staging directories older than this many hours
-     */
-    public function cleanupOldStagingDirectories($hoursOld = 24)
-    {
-        $stagingBasePath = $this->getStagingBasePath();
-        if (!is_dir($stagingBasePath)) {
-            return;
-        }
-
-        $cutoffTime = time() - ($hoursOld * 3600);
-        $dirs = array_diff(scandir($stagingBasePath), ['.', '..']);
-
-        foreach ($dirs as $dir) {
-            $dirPath = $stagingBasePath . DIRECTORY_SEPARATOR . $dir;
-            if (is_dir($dirPath) && filemtime($dirPath) < $cutoffTime) {
-                try {
-                    $this->recursiveDelete($dirPath);
-                    error_log("Cleaned up old staging directory: {$dirPath}");
-                } catch (Exception $e) {
-                    error_log("Failed to clean up staging directory: " . $e->getMessage());
-                }
-            }
-        }
-    }
-
     public function getJournalVersion()
     {
-        $versionDao = DAORegistry::getDAO('VersionDAO');
+        $versionDao = DAORegistry::getDAO('VersionDAO'); /** @var VersionDAO $versionDao */
         $version    = $versionDao->getCurrentVersion();
         $data       = $version->_data;
         return $data['major'] . $data['minor'];
@@ -1118,50 +665,6 @@ d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 01
         $pluginSettingsDAO->flushCache();
 
         return true;
-    }
-
-    function getDirs($path, $recursive = false, array $filtered = [])
-    {
-        $this->createModulesFolder();
-
-        if (!is_dir($path)) {
-            throw new RuntimeException("$path does not exist.");
-        }
-
-        $filtered += ['.', '..', '.git', 'pluginTemplate'];
-
-        $dirs = [];
-        $d = dir($path);
-
-        while (($entry = $d->read()) !== false) {
-            if (is_dir("$path/$entry") && !in_array($entry, $filtered)) {
-                $dirs[] = $entry;
-
-                if ($recursive) {
-                    $newDirs = $this->getDirs("$path/$entry");
-                    foreach ($newDirs as $newDir) {
-                        $dirs[] = "$entry/$newDir";
-                    }
-                }
-            }
-        }
-        sort($dirs);
-
-        return $dirs;
-    }
-
-    public function isDiagnosticEnabled()
-    {
-        return $this->getSetting(CONTEXT_SITE, 'enable_diagnostic') ?? true;
-    }
-
-    function str_contains($haystack, $needle)
-    {
-        if (!$haystack) {
-            return false;
-        }
-
-        return $needle !== '' && mb_strpos($haystack, $needle) !== false;
     }
 
     public function getAssetUrl($asset)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,165 @@
-# OJT Plugin
+# OJT Plugin (OJT Control Panel)
 
-OJTPlugin is a plugin wrapper for OJS that collect all Plugin created by OpenJournalTheme team.
+`ojtPlugin` is the base ecosystem plugin for OpenJournalTheme plugins in OJS.
+It provides:
+
+1. A shared control panel page (`/index.php/{contextPath}/ojt`)
+2. A modules ecosystem (`plugins/generic/ojtPlugin/modules/*`)
+3. A shared background job system (`OjtJobs` + WorkerBee queue hooks)
+4. Shared integration hooks for other OJT plugins
+
 ![Screenshot](assets/img/app.png)
 
-## Feature
+## What This Plugin Handles
 
-Work in progress
+- Registers OJT routes and handlers:
+  - `ojt/*` -> `OjtPageHandler`
+  - `ojt/api/*` -> `OjtPluginApiHandler`
+- Loads and registers child plugins from `modules/`
+- Adds OJT menu entry in backend for Manager/Site Admin
+- Provides shared queue dispatch and processing hooks
+- Provides plugin install/update plumbing for OJT marketplace flow
+- Provides sitemap integration endpoint for module plugins via `getSitemapData()`
 
-## Development
+## Jobs Ecosystem (How It Works)
 
-Work in progress
+### 1) Register job handlers in your plugin
+
+```php
+import('plugins.generic.ojtPlugin.Jobs');
+import('plugins.generic.yourPlugin.workers.YourJob');
+
+class YourPlugin extends GenericPlugin {
+    public function register($category, $path, $mainContextId = null) {
+        $success = parent::register($category, $path, $mainContextId);
+        if ($success && $this->getEnabled()) {
+            OjtJobs::register($this, [
+                new YourJob($this),
+            ]);
+        }
+        return $success;
+    }
+}
+```
+
+### 2) Create a job class (recommended: extend `BaseJob`)
+
+```php
+use Openjournalteam\OjtPlugin\Jobs\BaseJob;
+
+class YourJob extends BaseJob {
+    const TYPE = 'yourPlugin.doSomething';
+
+    public function getType() {
+        return self::TYPE;
+    }
+
+    public function handle(array $payload = [], array $data = []) {
+        // Your async logic here
+        return true;
+    }
+}
+```
+
+### 3) Dispatch the job
+
+```php
+OjtJobs::dispatch(
+    $this,
+    'yourPlugin.doSomething',
+    ['foo' => 'bar'],
+    [
+        'queue' => 'default',
+        'delaySeconds' => 0,
+        'contextId' => $this->getCurrentContextId(),
+        'maxAttempts' => 3,
+    ]
+);
+```
+
+### 4) Run the worker
+
+From OJS root:
+
+```bash
+php plugins/generic/ojtPlugin/tools/worker.php --queue=default
+```
+
+Useful flags:
+
+- `--once`
+- `--stop-when-empty`
+- `--sleep=3`
+- `--tries=3`
+- `--timeout=60`
+- `--memory=128`
+
+### Queue Lifecycle Hooks Available
+
+The queue handler calls these hooks:
+
+- `OjtPlugin::beforeProcessJob`
+- `OjtPlugin::processJob` (used by `OjtJobs`)
+- `OjtPlugin::afterProcessJob`
+- `OjtPlugin::jobFailed`
+
+## Integrating Other Plugins Into OJT Control Panel
+
+There are two common integration styles.
+
+### A) Plugin lives inside `ojtPlugin/modules`
+
+If your plugin is installed in `modules/`, it is auto-discovered when it has valid `version.xml` + `index.php`.
+
+Optional methods your plugin can expose (used by module registry):
+
+- `getPageIcon()`
+- `getDocumentation()`
+- `getPage()`
+- `getSitemapData()`
+- `getCanDelete()`
+- `getCanEnable()`
+
+### B) Site-wide plugin in `plugins/generic/*`
+
+Hook into OJT installed plugins list:
+
+```php
+HookRegistry::register('OjtPageHandler::installed::plugins', [$this, 'embedPluginToModules']);
+```
+
+Inside callback, append plugin metadata array (pattern used by `ojtAdvanceSecurity` / `ojtBlazingCachePro`):
+
+- `version`, `name`, `className`, `description`, `enabled`
+- `isAuthorized`, `icon`, `documentation`, `page`, `sitemapData`, `canDelete`
+
+## Frontend/Backend Hook Integration Points
+
+Available shared hooks you can use from other plugins:
+
+- `OjtPageHandler::index`
+  - Modify control panel view data object before rendering
+- `OjtPageHandler::installed::plugins`
+  - Inject plugin cards into installed plugin list
+
+Also, if your plugin exposes sitemap data:
+
+- Implement `getSitemapData()` returning:
+  - `productName`
+  - `productDescription`
+  - `productInstalledDate`
+  - `productVersion`
+  - `productUrl`
+  - `productLongDescription` (non-empty to be included)
+
+OJT will expose it under:
+
+- `/{journalPath}/about-product/{PluginClassName}`
+
+## Minimal Integration Checklist For New Plugin
+
+1. Register plugin normally in OJS
+2. If using queue: register jobs with `OjtJobs::register(...)`
+3. If site-wide and you want to appear in OJT list: hook `OjtPageHandler::installed::plugins`
+4. Optionally implement `getDocumentation()`, `getPageIcon()`, `getPage()`, `getSitemapData()`
+5. Start queue worker for async jobs

--- a/helpers/OJTHelper.inc.php
+++ b/helpers/OJTHelper.inc.php
@@ -77,6 +77,17 @@ if (!function_exists('cleanHtml')) {
     }
 }
 
+if (!function_exists('ojt_str_contains')) {
+    function ojt_str_contains($haystack, $needle)
+    {
+        if (!$haystack) {
+            return false;
+        }
+
+        return $needle !== '' && mb_strpos($haystack, $needle) !== false;
+    }
+}
+
 if (!function_exists('vd')) {
     function vd($value)
     {

--- a/src/Jobs/BaseJob.php
+++ b/src/Jobs/BaseJob.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Openjournalteam\OjtPlugin\Jobs;
+
+use OpenJournalteam\OjtPlugin\Jobs\JobInterface;
+
+abstract class BaseJob implements JobInterface
+{
+    /** @var \LazyLoadPlugin */
+    protected $plugin;
+
+    /** @var \OjtPlugin|false|null */
+    protected static $ojtPlugin = null;
+
+    public function __construct($plugin)
+    {
+        $this->plugin = $plugin;
+    }
+
+    /**
+     * @copydoc JobInterface::getQueue()
+     */
+    public function getQueue()
+    {
+        return 'default';
+    }
+
+    /**
+     * @copydoc JobInterface::isRequireRuntimeBaseUrl()
+     */
+    public function isRequireRuntimeBaseUrl()
+    {
+        return false;
+    }
+
+    /**
+     * @copydoc JobInterface::dispatch()
+     */
+    public function dispatch(array $payload = [], array $options = [])
+    {
+        $ojtPlugin = $this->getOjtPlugin();
+        if (!$ojtPlugin) {
+            return null;
+        }
+
+        if (!isset($options['queue'])) {
+            $options['queue'] = $this->getQueue();
+        }
+
+        return self::$ojtPlugin::dispatch($this->getType(), $payload, $options);
+    }
+
+    /**
+     * Check OjtWorkerBee plugin availability.
+     *
+     * @return mixed|null
+     */
+    protected function getOjtPlugin()
+    {
+        if (self::$ojtPlugin !== null) {
+            return self::$ojtPlugin ?: null;
+        }
+
+        import('plugins.generic.ojtPlugin.modules.ojtWorkerBee.OjtWorkerBeePlugin');
+        $plugin = \OjtPlugin::get();
+        if (!$plugin || !$plugin->isEnabledForRuntime()) {
+            error_log('OjtBlazingCachePro: OjtWorkerBee plugin is not installed or enabled.');
+            self::$ojtPlugin = false;
+            return null;
+        }
+
+        self::$ojtPlugin = $plugin;
+        return $plugin;
+    }
+}

--- a/src/Jobs/BaseJob.php
+++ b/src/Jobs/BaseJob.php
@@ -2,8 +2,6 @@
 
 namespace Openjournalteam\OjtPlugin\Jobs;
 
-use OpenJournalteam\OjtPlugin\Jobs\JobInterface;
-
 abstract class BaseJob implements JobInterface
 {
     /** @var \LazyLoadPlugin */
@@ -43,6 +41,10 @@ abstract class BaseJob implements JobInterface
             return null;
         }
 
+        if ($this->isRequireRuntimeBaseUrl()) {
+            $payload = $this->ensureRuntimeBaseUrl($payload);
+        }
+
         if (!isset($options['queue'])) {
             $options['queue'] = $this->getQueue();
         }
@@ -61,15 +63,41 @@ abstract class BaseJob implements JobInterface
             return self::$ojtPlugin ?: null;
         }
 
-        import('plugins.generic.ojtPlugin.modules.ojtWorkerBee.OjtWorkerBeePlugin');
         $plugin = \OjtPlugin::get();
-        if (!$plugin || !$plugin->isEnabledForRuntime()) {
-            error_log('OjtBlazingCachePro: OjtWorkerBee plugin is not installed or enabled.');
+        if (!$plugin || !$plugin->jobQueueService()->isEnabledForRuntime()) {
+            error_log('OjtPlugin: job queue service is not enabled for runtime.');
             self::$ojtPlugin = false;
             return null;
         }
 
         self::$ojtPlugin = $plugin;
         return $plugin;
+    }
+
+    /**
+     * Attach runtime base URL when dispatched from web request.
+     *
+     * @param array $payload
+     * @return array
+     */
+    protected function ensureRuntimeBaseUrl(array $payload)
+    {
+        if (!empty($payload['baseUrl']) || !empty($payload['runtimeBaseUrl'])) {
+            return $payload;
+        }
+
+        try {
+            $request = \Application::get()->getRequest();
+            if ($request && method_exists($request, 'getBaseUrl')) {
+                $baseUrl = trim((string) $request->getBaseUrl());
+                if ($baseUrl !== '') {
+                    $payload['runtimeBaseUrl'] = $baseUrl;
+                }
+            }
+        } catch (\Throwable $e) {
+            // Ignore and allow JobUrlResolver to fall back to config/env.
+        }
+
+        return $payload;
     }
 }

--- a/src/Jobs/Handlers/JobHandler.php
+++ b/src/Jobs/Handlers/JobHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Openjournalteam\OjtPlugin\Jobs\Handlers;
+
+use Exception;
+use HookRegistry;
+use Throwable;
+
+class JobHandler
+{
+    /**
+     * Laravel queue job entrypoint.
+     *
+     * @param \Illuminate\Contracts\Queue\Job $job
+     * @param array $data
+     * @return void
+     * @throws Throwable
+     */
+    public function fire($job, $data)
+    {
+        $jobType = isset($data['jobType']) ? (string) $data['jobType'] : '';
+        $payload = isset($data['payload']) && is_array($data['payload']) ? $data['payload'] : [];
+        $handled = false;
+        $result = null;
+        $error = null;
+
+        try {
+            HookRegistry::call('OjtPlugin::beforeProcessJob', [&$jobType, &$payload, &$data, &$job]);
+            HookRegistry::call('OjtPlugin::processJob', [&$jobType, &$payload, &$handled, &$result, &$job, &$data]);
+
+            if (!$handled) {
+                throw new Exception('No handler registered for WorkerBee job type: ' . $jobType);
+            }
+
+            HookRegistry::call('OjtPlugin::afterProcessJob', [&$jobType, &$payload, &$result, &$job, &$data]);
+            $job->delete();
+        } catch (Throwable $th) {
+            $error = $th;
+            HookRegistry::call('OjtPlugin::jobFailed', [&$jobType, &$payload, &$error, &$job, &$data]);
+
+            // Respect per-job max attempts from payload so jobs can fail immediately
+            // (Laravel-style failed job) when requested by dispatcher.
+            $maxAttempts = isset($data['maxAttempts']) ? max(1, (int) $data['maxAttempts']) : null;
+            if ($maxAttempts !== null && method_exists($job, 'attempts')) {
+                $attempts = (int) $job->attempts();
+                if ($attempts >= $maxAttempts && method_exists($job, 'fail')) {
+                    $job->fail($th);
+                    return;
+                }
+            }
+
+            throw $th;
+        }
+    }
+}

--- a/src/Jobs/JobInterface.php
+++ b/src/Jobs/JobInterface.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Openjournalteam\OjtPlugin\Jobs;
+
+interface JobInterface
+{
+    /**
+     * Unique job type string stored in queue payload.
+     *
+     * @return string
+     */
+    public function getType();
+
+    /**
+     * Default queue name.
+     *
+     * @return string
+     */
+    public function getQueue();
+
+    /**
+     * Dispatch this job through WorkerBee.
+     *
+     * @param array $payload
+     * @param array $options
+     * @return mixed
+     */
+    public function dispatch(array $payload = [], array $options = []);
+
+    /**
+     * Handle queued payload.
+     *
+     * @param array $payload
+     * @param array $data
+     * @return mixed
+     */
+    public function handle(array $payload = [], array $data = []);
+
+    /**
+     * Whether this job requires runtime base URL enrichment.
+     *
+     * @return bool
+     */
+    public function isRequireRuntimeBaseUrl();
+}

--- a/src/Jobs/JobUrlResolver.inc.php
+++ b/src/Jobs/JobUrlResolver.inc.php
@@ -1,0 +1,240 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+class OjtBlazingCacheProJobUrlResolver
+{
+    /** @var array<int,string> */
+    protected static $contextPathCache = [];
+
+    /**
+     * Build full cache URL for page-cache jobs.
+     *
+     * @param int|null $contextId
+     * @param string $page
+     * @param string $op
+     * @param array $args
+     * @param array $queryVars
+     * @param string|null $explicitBaseUrl
+     * @return string
+     */
+    public function buildCachePageUrl($contextId, $page, $op, array $args = [], array $queryVars = [], $explicitBaseUrl = null)
+    {
+        $resolvedContextId = (int) ($contextId ?: 0);
+        $contextPath = $this->getContextPath($resolvedContextId);
+        $baseUrl = $this->resolveBaseUrl($contextPath, $explicitBaseUrl);
+
+        return $this->buildAbsolutePageUrl($baseUrl, $contextPath, $page, $op, $args, $queryVars);
+    }
+
+    /**
+     * Resolve and cache journal context path by context id.
+     *
+     * @param int $contextId
+     * @return string
+     */
+    public function getContextPath($contextId)
+    {
+        $contextId = (int) $contextId;
+        if (isset(self::$contextPathCache[$contextId])) {
+            return self::$contextPathCache[$contextId];
+        }
+
+        $contextPath = Capsule::table('journals')
+            ->where('journal_id', $contextId)
+            ->value('path');
+
+        if (!$contextPath) {
+            $contextPath = 'index';
+        }
+
+        self::$contextPathCache[$contextId] = (string) $contextPath;
+        return self::$contextPathCache[$contextId];
+    }
+
+    /**
+     * Resolve base URL candidate list for jobs/CLI runtime.
+     *
+     * @param string $contextPath
+     * @param string|null $explicitBaseUrl
+     * @return string
+     */
+    protected function resolveBaseUrl($contextPath, $explicitBaseUrl = null)
+    {
+        $candidates = [];
+
+        if ($explicitBaseUrl !== null && trim((string) $explicitBaseUrl) !== '') {
+            $candidates[] = trim((string) $explicitBaseUrl);
+        }
+
+        $envBase = getenv('OJT_BLAZING_CACHE_BASE_URL');
+        if ($envBase !== false && trim((string) $envBase) !== '') {
+            $candidates[] = trim((string) $envBase);
+        }
+
+        $appUrl = getenv('APP_URL');
+        if ($appUrl !== false && trim((string) $appUrl) !== '') {
+            $candidates[] = trim((string) $appUrl);
+        }
+
+        $contextBase = \Config::getVar('general', 'base_url[' . $contextPath . ']');
+        if ($contextBase && trim((string) $contextBase) !== '') {
+            $candidates[] = trim((string) $contextBase);
+        }
+
+        $indexBase = \Config::getVar('general', 'base_url[index]');
+        if ($indexBase && trim((string) $indexBase) !== '') {
+            $candidates[] = trim((string) $indexBase);
+        }
+
+        $generalBase = \Config::getVar('general', 'base_url');
+        if ($generalBase && trim((string) $generalBase) !== '') {
+            $candidates[] = trim((string) $generalBase);
+        }
+
+        $allowedHosts = $this->getAllowedHosts($candidates);
+
+        foreach ($candidates as $candidate) {
+            $candidate = $this->sanitizeBaseUrlCandidate($candidate, $allowedHosts);
+            if ($candidate === '') {
+                continue;
+            }
+
+            // Ignore known OJS sample fallback URL.
+            if (stripos($candidate, 'pkp.sfu.ca/ojs') !== false) {
+                continue;
+            }
+
+            return rtrim($candidate, '/');
+        }
+
+        return $this->inferLocalBaseUrlFromProject();
+    }
+
+    /**
+     * Build absolute page URL from base/context/page segments.
+     *
+     * @param string $baseUrl
+     * @param string $contextPath
+     * @param string $page
+     * @param string $op
+     * @param array $args
+     * @param array $queryVars
+     * @return string
+     */
+    protected function buildAbsolutePageUrl($baseUrl, $contextPath, $page, $op, array $args = [], array $queryVars = [])
+    {
+        $baseUrl = rtrim((string) $baseUrl, '/');
+        if (substr($baseUrl, -10) === '/index.php') {
+            $baseUrl = substr($baseUrl, 0, -10);
+        }
+
+        $segments = [
+            'index.php',
+            rawurlencode((string) $contextPath),
+            rawurlencode((string) $page),
+        ];
+
+        if ($op !== null && $op !== '') {
+            $segments[] = rawurlencode((string) $op);
+        }
+
+        foreach ($args as $arg) {
+            if ($arg === null || $arg === '') {
+                continue;
+            }
+            $segments[] = rawurlencode((string) $arg);
+        }
+
+        $url = $baseUrl . '/' . implode('/', $segments);
+        if (!empty($queryVars)) {
+            $query = http_build_query($queryVars, '', '&', PHP_QUERY_RFC3986);
+            if ($query !== '') {
+                $url .= '?' . $query;
+            }
+        }
+
+        return $url;
+    }
+
+    /**
+     * Only allow absolute HTTP(S) URLs.
+     *
+     * @param string $candidate
+     * @param array $allowedHosts
+     * @return string
+     */
+    protected function sanitizeBaseUrlCandidate($candidate, array $allowedHosts = [])
+    {
+        $candidate = trim((string) $candidate);
+        if ($candidate === '') {
+            return '';
+        }
+
+        $parts = parse_url($candidate);
+        if ($parts === false || empty($parts['scheme']) || empty($parts['host'])) {
+            return '';
+        }
+
+        $scheme = strtolower((string) $parts['scheme']);
+        if ($scheme !== 'http' && $scheme !== 'https') {
+            return '';
+        }
+
+        $host = strtolower((string) $parts['host']);
+        if (!empty($allowedHosts) && !in_array($host, $allowedHosts, true)) {
+            return '';
+        }
+
+        return $candidate;
+    }
+
+    /**
+     * Build allowed host list from trusted candidate sources.
+     *
+     * @param array $candidates
+     * @return array
+     */
+    protected function getAllowedHosts(array $candidates = [])
+    {
+        $hosts = [];
+
+        foreach ($candidates as $candidate) {
+            $parts = parse_url((string) $candidate);
+            if ($parts === false || empty($parts['host'])) {
+                continue;
+            }
+
+            $host = strtolower((string) $parts['host']);
+            if ($host !== '' && !in_array($host, $hosts, true)) {
+                $hosts[] = $host;
+            }
+        }
+
+        // Ensure fallback local host is always allowed.
+        $fallbackHost = parse_url($this->inferLocalBaseUrlFromProject(), PHP_URL_HOST);
+        if ($fallbackHost) {
+            $fallbackHost = strtolower((string) $fallbackHost);
+            if (!in_array($fallbackHost, $hosts, true)) {
+                $hosts[] = $fallbackHost;
+            }
+        }
+
+        return $hosts;
+    }
+
+    /**
+     * Local fallback for CLI/dev runtime.
+     *
+     * @return string
+     */
+    protected function inferLocalBaseUrlFromProject()
+    {
+        $projectDir = basename((string) \Core::getBaseDir());
+        if ($projectDir === '' || $projectDir === '.' || $projectDir === DIRECTORY_SEPARATOR) {
+            return 'http://localhost';
+        }
+
+        return 'http://localhost/' . rawurlencode($projectDir);
+    }
+}

--- a/src/Jobs/JobUrlResolver.php
+++ b/src/Jobs/JobUrlResolver.php
@@ -1,8 +1,10 @@
 <?php
 
+namespace Openjournalteam\OjtPlugin\Jobs;
+
 use Illuminate\Database\Capsule\Manager as Capsule;
 
-class OjtBlazingCacheProJobUrlResolver
+class JobUrlResolver
 {
     /** @var array<int,string> */
     protected static $contextPathCache = [];
@@ -67,6 +69,11 @@ class OjtBlazingCacheProJobUrlResolver
             $candidates[] = trim((string) $explicitBaseUrl);
         }
 
+        $serverBase = $this->getServerBaseUrlCandidate();
+        if ($serverBase !== '') {
+            $candidates[] = $serverBase;
+        }
+
         $envBase = getenv('OJT_BLAZING_CACHE_BASE_URL');
         if ($envBase !== false && trim((string) $envBase) !== '') {
             $candidates[] = trim((string) $envBase);
@@ -109,6 +116,50 @@ class OjtBlazingCacheProJobUrlResolver
         }
 
         return $this->inferLocalBaseUrlFromProject();
+    }
+
+    /**
+     * Build base URL from server globals (web runtime).
+     *
+     * @return string
+     */
+    protected function getServerBaseUrlCandidate()
+    {
+        if (PHP_SAPI === 'cli') {
+            return '';
+        }
+
+        $host = '';
+        if (!empty($_SERVER['HTTP_HOST'])) {
+            $host = (string) $_SERVER['HTTP_HOST'];
+        } elseif (!empty($_SERVER['SERVER_NAME'])) {
+            $host = (string) $_SERVER['SERVER_NAME'];
+        }
+
+        if ($host === '') {
+            return '';
+        }
+
+        $scheme = 'http';
+        if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+            $scheme = strtolower((string) $_SERVER['HTTP_X_FORWARDED_PROTO']);
+        } elseif (!empty($_SERVER['REQUEST_SCHEME'])) {
+            $scheme = strtolower((string) $_SERVER['REQUEST_SCHEME']);
+        } elseif (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
+            $scheme = 'https';
+        }
+
+        $basePath = '';
+        if (!empty($_SERVER['SCRIPT_NAME'])) {
+            $basePath = rtrim(dirname((string) $_SERVER['SCRIPT_NAME']), '/');
+        }
+
+        $url = $scheme . '://' . $host;
+        if ($basePath !== '' && $basePath !== '.') {
+            $url .= $basePath;
+        }
+
+        return $url;
     }
 
     /**

--- a/src/Jobs/WorkerTool.php
+++ b/src/Jobs/WorkerTool.php
@@ -87,7 +87,7 @@ class WorkerTool extends \CommandLineTool
 
         $events = $laravelContainer['events'];
 
-        \HookRegistry::register('OjtWorkerBee::jobFailed', [$this, 'onWorkerBeeJobFailed']);
+        \HookRegistry::register('OjtPlugin::jobFailed', [$this, 'onWorkerBeeJobFailed']);
 
         $events->listen('Illuminate\Queue\Events\JobProcessing', function ($event) {
             $jobId = $this->getEventJobId($event);
@@ -164,7 +164,7 @@ class WorkerTool extends \CommandLineTool
     }
 
     /**
-     * Persist failed job details to ojt_worker_bee_failed_jobs (Laravel-like).
+     * Persist failed job details to failed jobs table (Laravel-like).
      *
      * @param mixed $event
      * @return void
@@ -219,7 +219,7 @@ class WorkerTool extends \CommandLineTool
             $contextId = (int) $payloadData['contextId'];
         }
 
-        Capsule::table('ojt_worker_bee_failed_jobs')->insert([
+        Capsule::table($this->getFailedJobsTableName())->insert([
             'connection' => $connection,
             'queue' => $queue,
             'payload' => (string) $payloadRaw,
@@ -237,11 +237,12 @@ class WorkerTool extends \CommandLineTool
     protected function ensureFailedJobsTable()
     {
         $schema = Capsule::schema();
-        if ($schema->hasTable('ojt_worker_bee_failed_jobs')) {
+        $table = $this->getFailedJobsTableName();
+        if ($schema->hasTable($table)) {
             return;
         }
 
-        $schema->create('ojt_worker_bee_failed_jobs', function (Blueprint $table) {
+        $schema->create($table, function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->text('connection');
             $table->text('queue');
@@ -251,6 +252,16 @@ class WorkerTool extends \CommandLineTool
             $table->timestamp('failed_at')->useCurrent();
             $table->index(['context_id']);
         });
+    }
+
+    /**
+     * Get failed jobs table name.
+     *
+     * @return string
+     */
+    protected function getFailedJobsTableName()
+    {
+        return \Openjournalteam\OjtPlugin\Services\JobQueueService::FAILED_JOBS_TABLE;
     }
 
     /**

--- a/src/Jobs/WorkerTool.php
+++ b/src/Jobs/WorkerTool.php
@@ -1,0 +1,391 @@
+<?php
+
+namespace Openjournalteam\OjtPlugin\Jobs;
+
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Database\Schema\Blueprint;
+
+class WorkerTool extends \CommandLineTool
+{
+    /** @var array */
+    protected $options = [
+        'queue' => 'default',
+        'sleep' => 3,
+        'tries' => 3,
+        'timeout' => 60,
+        'memory' => 128,
+        'once' => false,
+        'stopWhenEmpty' => false,
+    ];
+
+    /** @var array */
+    protected $jobStartTimes = [];
+
+    /** @var array */
+    protected $failedJobIds = [];
+
+    public function __construct($argv = [])
+    {
+        parent::__construct($argv);
+        $this->parseOptions();
+    }
+
+    public function usage()
+    {
+        echo "Usage: php plugins/generic/ojtPlugin/modules/ojtWorkerBee/tools/worker.php [options]\n";
+        echo "Options:\n";
+        echo "  --queue=NAME         Queue name (default: default)\n";
+        echo "  --sleep=SECONDS      Poll sleep seconds (default: 3)\n";
+        echo "  --tries=INT          Max tries per job (default: 3)\n";
+        echo "  --timeout=SECONDS    Job timeout (default: 60)\n";
+        echo "  --memory=MB          Worker memory limit (default: 128)\n";
+        echo "  --once               Process only one job then exit\n";
+        echo "  --stop-when-empty    Exit daemon when queue is empty\n";
+    }
+
+    public function execute()
+    {
+        $plugin = \OjtPlugin::get();
+        if (!$plugin || !$plugin->isEnabledForRuntime()) {
+            fwrite(STDERR, "OJT Worker Bee plugin is not enabled.\n");
+            exit(1);
+        }
+
+        $this->registerQueueLogging();
+
+        $service = $plugin->jobQueueService();
+
+        if ($this->options['once']) {
+            try {
+                $service->runNext($this->options['queue'], $this->options);
+            } catch (\Throwable $e) {
+                // Keep CLI output readable; details are persisted in failed jobs table.
+                $time = date('Y-m-d H:i:s');
+                fwrite(STDOUT, sprintf('[%s] Failed: Worker runtime error. Reason: %s', $time, $e->getMessage()) . PHP_EOL);
+            }
+            return;
+        }
+
+        try {
+            $service->daemon($this->options['queue'], $this->options);
+        } catch (\Throwable $e) {
+            // Keep CLI output readable; details are persisted in failed jobs table.
+            $time = date('Y-m-d H:i:s');
+            fwrite(STDOUT, sprintf('[%s] Failed: Worker runtime error. Reason: %s', $time, $e->getMessage()) . PHP_EOL);
+        }
+    }
+
+    /**
+     * Register CLI log output for processing/success/failure job events.
+     */
+    protected function registerQueueLogging()
+    {
+        $laravelContainer = \Registry::get('laravelContainer');
+        if (!$laravelContainer || !isset($laravelContainer['events'])) {
+            return;
+        }
+
+        $events = $laravelContainer['events'];
+
+        \HookRegistry::register('OjtWorkerBee::jobFailed', [$this, 'onWorkerBeeJobFailed']);
+
+        $events->listen('Illuminate\Queue\Events\JobProcessing', function ($event) {
+            $jobId = $this->getEventJobId($event);
+            $jobType = $this->getEventJobType($event);
+            $this->jobStartTimes[$jobId] = microtime(true);
+            $this->logLine('processing', $jobId, $jobType);
+        });
+
+        $events->listen('Illuminate\Queue\Events\JobProcessed', function ($event) {
+            $jobId = $this->getEventJobId($event);
+            if (isset($event->job) && method_exists($event->job, 'hasFailed') && $event->job->hasFailed()) {
+                return;
+            }
+            if (isset($this->failedJobIds[$jobId])) {
+                unset($this->failedJobIds[$jobId]);
+                return;
+            }
+            $jobType = $this->getEventJobType($event);
+            $duration = $this->consumeDuration($jobId);
+            $this->logLine('success', $jobId, $jobType, $duration);
+        });
+
+        $events->listen('Illuminate\Queue\Events\JobFailed', function ($event) {
+            $jobId = $this->getEventJobId($event);
+            if (isset($this->failedJobIds[$jobId])) {
+                return;
+            }
+            $jobType = $this->getEventJobType($event);
+            $duration = $this->consumeDuration($jobId);
+            $error = isset($event->exception) ? $event->exception->getMessage() : 'unknown error';
+            $this->failedJobIds[$jobId] = true;
+            $this->persistFailedJob($event);
+            $this->logLine('failed', $jobId, $jobType, $duration, $error);
+        });
+    }
+
+    /**
+     * WorkerBee direct failure hook handler (reliable across runtime differences).
+     *
+     * @param string $hookName
+     * @param array $args
+     * @return bool
+     */
+    public function onWorkerBeeJobFailed($hookName, $args)
+    {
+        $jobType = isset($args[0]) ? (string) $args[0] : 'unknown';
+        $payload = isset($args[1]) && is_array($args[1]) ? $args[1] : [];
+        $error = isset($args[2]) ? $args[2] : null;
+        $job = isset($args[3]) ? $args[3] : null;
+        $data = isset($args[4]) && is_array($args[4]) ? $args[4] : [];
+
+        $jobId = ($job && method_exists($job, 'getJobId')) ? (string) $job->getJobId() : 'n/a';
+        if (isset($this->failedJobIds[$jobId])) {
+            return false;
+        }
+
+        $this->failedJobIds[$jobId] = true;
+        $duration = $this->consumeDuration($jobId);
+
+        $message = 'unknown error';
+        $exceptionText = null;
+        if ($error instanceof \Throwable) {
+            $message = $error->getMessage();
+            $exceptionText = (string) $error;
+        } elseif (is_string($error) && $error !== '') {
+            $message = $error;
+            $exceptionText = $error;
+        }
+
+        $this->persistFailedJobFromData($job, $data, $payload, $exceptionText, $jobType);
+        $this->logLine('failed', $jobId, $jobType, $duration, $message);
+
+        return false;
+    }
+
+    /**
+     * Persist failed job details to ojt_worker_bee_failed_jobs (Laravel-like).
+     *
+     * @param mixed $event
+     * @return void
+     */
+    protected function persistFailedJob($event)
+    {
+        try {
+            $this->ensureFailedJobsTable();
+
+            $job = isset($event->job) ? $event->job : null;
+            if (!$job) {
+                return;
+            }
+
+            $payloadData = method_exists($job, 'payload') ? $job->payload() : [];
+            $exception = isset($event->exception) ? (string) $event->exception : 'Unknown exception';
+            $this->persistFailedJobFromData($job, $payloadData, $payloadData, $exception);
+        } catch (\Throwable $e) {
+            error_log('OjtWorkerBee failed-job persistence error: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Persist failed job row from normalized inputs.
+     *
+     * @param mixed $job
+     * @param array $data
+     * @param array $payloadData
+     * @param string|null $exception
+     * @param string|null $jobType
+     * @return void
+     */
+    protected function persistFailedJobFromData($job, array $data = [], array $payloadData = [], $exception = null, $jobType = null)
+    {
+        $this->ensureFailedJobsTable();
+
+        $payloadRaw = ($job && method_exists($job, 'getRawBody'))
+            ? $job->getRawBody()
+            : json_encode($payloadData);
+        $queue = ($job && method_exists($job, 'getQueue')) ? (string) $job->getQueue() : 'default';
+        $connection = ($job && method_exists($job, 'getConnectionName')) ? (string) $job->getConnectionName() : 'default';
+        $exceptionText = $exception ? (string) $exception : 'Unknown exception';
+
+        $contextId = null;
+        if (isset($data['contextId']) && (int) $data['contextId'] > 0) {
+            $contextId = (int) $data['contextId'];
+        } elseif (isset($payloadData['data']['data']['contextId']) && (int) $payloadData['data']['data']['contextId'] > 0) {
+            $contextId = (int) $payloadData['data']['data']['contextId'];
+        } elseif (isset($payloadData['data']['contextId']) && (int) $payloadData['data']['contextId'] > 0) {
+            $contextId = (int) $payloadData['data']['contextId'];
+        } elseif (isset($payloadData['contextId']) && (int) $payloadData['contextId'] > 0) {
+            $contextId = (int) $payloadData['contextId'];
+        }
+
+        Capsule::table('ojt_worker_bee_failed_jobs')->insert([
+            'connection' => $connection,
+            'queue' => $queue,
+            'payload' => (string) $payloadRaw,
+            'exception' => $exceptionText,
+            'context_id' => $contextId,
+            'failed_at' => date('Y-m-d H:i:s'),
+        ]);
+    }
+
+    /**
+     * Ensure failed jobs table exists before insert.
+     *
+     * @return void
+     */
+    protected function ensureFailedJobsTable()
+    {
+        $schema = Capsule::schema();
+        if ($schema->hasTable('ojt_worker_bee_failed_jobs')) {
+            return;
+        }
+
+        $schema->create('ojt_worker_bee_failed_jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->unsignedInteger('context_id')->nullable();
+            $table->timestamp('failed_at')->useCurrent();
+            $table->index(['context_id']);
+        });
+    }
+
+    /**
+     * Build event job id safely.
+     *
+     * @param mixed $event
+     * @return string
+     */
+    protected function getEventJobId($event)
+    {
+        if (isset($event->job) && method_exists($event->job, 'getJobId')) {
+            $jobId = $event->job->getJobId();
+            if ($jobId !== null && $jobId !== '') {
+                return (string) $jobId;
+            }
+        }
+
+        return 'n/a';
+    }
+
+    /**
+     * Build event job type safely.
+     *
+     * @param mixed $event
+     * @return string
+     */
+    protected function getEventJobType($event)
+    {
+        if (!isset($event->job) || !method_exists($event->job, 'payload')) {
+            return 'unknown';
+        }
+
+        $payload = $event->job->payload();
+        if (!is_array($payload)) {
+            return 'unknown';
+        }
+
+        if (isset($payload['data']['data']['jobType']) && $payload['data']['data']['jobType']) {
+            return (string) $payload['data']['data']['jobType'];
+        }
+
+        if (isset($payload['data']['jobType']) && $payload['data']['jobType']) {
+            return (string) $payload['data']['jobType'];
+        }
+
+        if (isset($payload['job']) && $payload['job']) {
+            return (string) $payload['job'];
+        }
+
+        return 'unknown';
+    }
+
+    /**
+     * Consume and calculate job elapsed time.
+     *
+     * @param string $jobId
+     * @return float|null
+     */
+    protected function consumeDuration($jobId)
+    {
+        if (!isset($this->jobStartTimes[$jobId])) {
+            return null;
+        }
+
+        $startedAt = $this->jobStartTimes[$jobId];
+        unset($this->jobStartTimes[$jobId]);
+
+        return microtime(true) - $startedAt;
+    }
+
+    /**
+     * Print one formatted log line to CLI.
+     *
+     * @param string $status
+     * @param string $jobId
+     * @param string $jobType
+     * @param float|null $duration
+     * @param string|null $error
+     */
+    protected function logLine($status, $jobId, $jobType, $duration = null, $error = null)
+    {
+        $time = date('Y-m-d H:i:s');
+        $prettyType = $jobType ?: 'Unknown job';
+
+        if ($status === 'processing') {
+            $line = sprintf('[%s] Starting: %s (Job #%s)', $time, $prettyType, $jobId);
+        } elseif ($status === 'success') {
+            $durationText = $duration !== null ? ' in ' . number_format((float) $duration * 1000, 0) . 'ms' : '';
+            $line = sprintf('[%s] Done: %s (Job #%s)%s', $time, $prettyType, $jobId, $durationText);
+        } else {
+            $durationText = $duration !== null ? ' after ' . number_format((float) $duration * 1000, 0) . 'ms' : '';
+            $errorText = $error ? ' Reason: ' . str_replace('"', "'", (string) $error) : '';
+            $line = sprintf('[%s] Failed: %s (Job #%s)%s.%s', $time, $prettyType, $jobId, $durationText, $errorText);
+        }
+
+        fwrite(STDOUT, $line . PHP_EOL);
+    }
+
+    protected function parseOptions()
+    {
+        foreach ($this->argv as $arg) {
+            if ($arg === '--once') {
+                $this->options['once'] = true;
+                continue;
+            }
+
+            if ($arg === '--stop-when-empty') {
+                $this->options['stopWhenEmpty'] = true;
+                continue;
+            }
+
+            if (strpos($arg, '--queue=') === 0) {
+                $this->options['queue'] = (string) substr($arg, 8);
+                continue;
+            }
+
+            if (strpos($arg, '--sleep=') === 0) {
+                $this->options['sleep'] = max(0, (int) substr($arg, 8));
+                continue;
+            }
+
+            if (strpos($arg, '--tries=') === 0) {
+                $this->options['tries'] = max(1, (int) substr($arg, 8));
+                continue;
+            }
+
+            if (strpos($arg, '--timeout=') === 0) {
+                $this->options['timeout'] = max(1, (int) substr($arg, 10));
+                continue;
+            }
+
+            if (strpos($arg, '--memory=') === 0) {
+                $this->options['memory'] = max(64, (int) substr($arg, 9));
+                continue;
+            }
+        }
+    }
+}

--- a/src/Migrations/MigrationManager.php
+++ b/src/Migrations/MigrationManager.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Openjournalteam\OjtPlugin\Migrations;
+
+class MigrationManager
+{
+    protected $_plugin;
+
+    public function __construct($plugin)
+    {
+        $this->_plugin = $plugin;
+    }
+
+    public static function make(...$args)
+    {
+        return new static(...$args);
+    }
+
+    public function getMigrations()
+    {
+        $migrations = [];
+        $migrationPath = $this->_plugin->getPluginPath() . "/src/Migrations/";
+
+        $files = glob($migrationPath . 'v*.php');
+        foreach ($files as $file) {
+            require_once $file;
+            $className = pathinfo($file, PATHINFO_FILENAME);
+            $fullClassName = "Openjournalteam\\OjtPlugin\\Migrations\\$className";
+
+            if (class_exists($fullClassName)) {
+                $migrations[$className] = new $fullClassName();
+            }
+        }
+
+        return $migrations;
+    }
+
+    public function runMigrations()
+    {
+        $migrations = $this->getMigrations();
+
+        foreach ($migrations as $version => $migration) {
+            if (!$this->_plugin->getSetting(CONTEXT_SITE, 'ojt_plugin_migration_' . $version)) {
+                $migration->up();
+                $this->_plugin->updateSetting(CONTEXT_SITE, 'ojt_plugin_migration_' . $version, true);
+            }
+        }
+    }
+
+    public function rollbackMigrations()
+    {
+        $migrations = $this->getMigrations();
+
+        foreach ($migrations as $version => $migration) {
+            if ($this->_plugin->getSetting(CONTEXT_SITE, 'ojt_plugin_migration_' . $version)) {
+                $migration->down();
+                $this->_plugin->updateSetting(CONTEXT_SITE, 'ojt_plugin_migration_' . $version, false);
+            }
+        }
+    }
+}

--- a/src/Migrations/v2_1_3_3.php
+++ b/src/Migrations/v2_1_3_3.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Openjournalteam\OjtPlugin\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Capsule\Manager as Capsule;
+
+class v2_1_3_3 extends Migration
+{
+    const JOBS_TABLE = 'ojt_jobs';
+    const FAILED_JOBS_TABLE = 'ojt_failed_jobs';
+
+    /**
+     * Run migration.
+     */
+    public function up()
+    {
+        $schema = Capsule::schema();
+        if (!$schema->hasTable(self::JOBS_TABLE)) {
+            $schema->create(self::JOBS_TABLE, function (Blueprint $table) {
+                // Keep same structure as Laravel "jobs" table for DB queue driver.
+                $table->bigIncrements('id');
+                $table->string('queue');
+                $table->longText('payload');
+                $table->unsignedTinyInteger('attempts');
+                $table->unsignedInteger('context_id')->nullable();
+                $table->unsignedInteger('reserved_at')->nullable();
+                $table->unsignedInteger('available_at');
+                $table->unsignedInteger('created_at');
+
+                $table->index(['queue', 'reserved_at']);
+                $table->index(['context_id']);
+            });
+        } elseif (!$schema->hasColumn(self::JOBS_TABLE, 'context_id')) {
+            // Upgrade existing jobs table.
+            $schema->table(self::JOBS_TABLE, function (Blueprint $table) {
+                $table->unsignedInteger('context_id')->nullable()->after('attempts');
+                $table->index(['context_id']);
+            });
+        }
+
+        if (!$schema->hasTable(self::FAILED_JOBS_TABLE)) {
+            $schema->create(self::FAILED_JOBS_TABLE, function (Blueprint $table) {
+                // Laravel-like failed jobs structure + context for journal isolation.
+                $table->bigIncrements('id');
+                $table->text('connection');
+                $table->text('queue');
+                $table->longText('payload');
+                $table->longText('exception');
+                $table->unsignedInteger('context_id')->nullable();
+                $table->timestamp('failed_at')->useCurrent();
+
+                $table->index(['context_id']);
+            });
+        } elseif (!$schema->hasColumn(self::FAILED_JOBS_TABLE, 'context_id')) {
+            $schema->table(self::FAILED_JOBS_TABLE, function (Blueprint $table) {
+                $table->unsignedInteger('context_id')->nullable()->after('exception');
+                $table->index(['context_id']);
+            });
+        }
+    }
+
+    /**
+     * Reverse migration.
+     */
+    public function down()
+    {
+        Capsule::schema()->dropIfExists(self::FAILED_JOBS_TABLE);
+        Capsule::schema()->dropIfExists(self::JOBS_TABLE);
+    }
+}

--- a/src/Migrations/v2_2_0_0.php
+++ b/src/Migrations/v2_2_0_0.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Capsule\Manager as Capsule;
 
-class v2_1_3_3 extends Migration
+class v2_2_0_0 extends Migration
 {
     const JOBS_TABLE = 'ojt_jobs';
     const FAILED_JOBS_TABLE = 'ojt_failed_jobs';

--- a/src/Services/HookService.php
+++ b/src/Services/HookService.php
@@ -20,7 +20,7 @@ class HookService
         \HookRegistry::register('TemplateManager::setupBackendPage', [$this, 'setupBackendPage']);
         \HookRegistry::register('TemplateManager::display', [$this, 'fixThemeNotLoadedOnFrontend']);
         // \HookRegistry::register('TemplateManager::display', [$this, 'addHeader']);
-        \HookRegistry::register('SitemapHandler::createJournalSitemap', [$this, 'addIndexingPage']);
+        \HookRegistry::register('SitemapHandler::createJournalSitemap', [$this->plugin, 'addIndexingPage']);
     }
 
     public function fixThemeNotLoadedOnFrontend($hookName, $args)
@@ -170,8 +170,5 @@ class HookService
         return false;
     }
 
-    public function addIndexingPage($hookName, $args)
-    {
-        return $this->plugin->addIndexingPage($hookName, $args);
-    }
+    // addIndexingPage handled directly by OjtPlugin (trait).
 }

--- a/src/Services/HookService.php
+++ b/src/Services/HookService.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Openjournalteam\OjtPlugin\Services;
+
+use Openjournalteam\OjtPlugin\Classes\IndexingPageHandler;
+
+class HookService
+{
+    private \OjtPlugin $plugin;
+
+    public function __construct(\OjtPlugin $plugin)
+    {
+        $this->plugin = $plugin;
+    }
+
+    public function registerHooks(): void
+    {
+        // HookRegistry::register('Template::Settings::website', array($this, 'settingsWebsite'));
+        \HookRegistry::register('LoadHandler', [$this, 'setPageHandler']);
+        \HookRegistry::register('TemplateManager::setupBackendPage', [$this, 'setupBackendPage']);
+        \HookRegistry::register('TemplateManager::display', [$this, 'fixThemeNotLoadedOnFrontend']);
+        // \HookRegistry::register('TemplateManager::display', [$this, 'addHeader']);
+        \HookRegistry::register('SitemapHandler::createJournalSitemap', [$this, 'addIndexingPage']);
+    }
+
+    public function fixThemeNotLoadedOnFrontend($hookName, $args)
+    {
+        $templateMgr            = $args[0];
+        if ($this->plugin->getJournalVersion() != '31') {
+            if ($templateMgr->getTemplateVars('activeTheme')) return;
+        }
+
+        $allThemes = \PluginRegistry::loadCategory('themes', true);
+        $activeTheme = null;
+        $context = $this->plugin->getCurrentContextId() ? $this->plugin->getRequest()->getContext() : $this->plugin->getRequest()->getSite();
+        $themePluginPath = $context->getData('themePluginPath');
+
+        foreach ($allThemes as $theme) {
+            if ($themePluginPath === basename($theme->pluginPath) && $theme->getEnabled()) {
+                $activeTheme = $theme;
+                break;
+            }
+        }
+
+        $templateMgr->assign('activeTheme', $activeTheme);
+    }
+
+    public function addHeader($hookName, $args)
+    {
+        $templateMgr            = &$args[0];
+
+        $templateMgr->addHeader(
+            'ojtcontrolpanel',
+            '<meta name="ojtcontrolpanel" content="OJT Control Panel Version ' . $this->plugin->getPluginVersion() . ' by openjournaltheme.com">',
+            [
+                'contexts' => ['frontend'],
+            ]
+        );
+    }
+
+    public function setupBackendPage($hookName, $args)
+    {
+        $request = $this->plugin->getRequest();
+
+        if (!$request->getContext()) return;
+
+        $templateMgr    = \TemplateManager::getManager($this->plugin->getRequest());
+        $router         = $request->getRouter();
+        $userRoles      = (array) $router->getHandler()->getAuthorizedContextObject(ASSOC_TYPE_USER_ROLES);
+        $user           = $request->getUser();
+
+        if (!$user || !count(array_intersect([ROLE_ID_MANAGER, ROLE_ID_SITE_ADMIN], $userRoles))) return;
+
+        $menu = $templateMgr->getState('menu');
+        $menu['ojtPlugin'] = [
+            'name' => 'OJT Control Panel',
+            'url' => $request->getDispatcher()->url($request, ROUTE_PAGE, $request->getContext()->getPath(), 'ojt') . '?PageSpeed=off',
+            "isCurrent" => false
+        ];
+
+        if ($this->plugin->getSetting($this->plugin->getCurrentContextId(), 'show_support_link_ojs') ?? true) {
+            $menu['ojtSupportTicketing'] = [
+                'name' => 'Get OJT support',
+                'url' => $request->getDispatcher()->url($request, ROUTE_PAGE, $request->getContext()->getPath(), 'ojt', 'support'),
+                "isCurrent" => false
+            ];
+        }
+
+        $templateMgr->setState(['menu' => $menu]);
+    }
+
+    public function setPageHandler($hookName, $params)
+    {
+        if ($this->plugin->getCurrentContextId() == 0) {
+            // Panel tidak support untuk sitewide
+            return false;
+        }
+
+        $page = $params[0];
+        $op   = &$params[1];
+
+        // Force http or https based on host
+        $request = \Application::get()->getRequest();
+        $serverHost = $request->getServerHost(null, false);
+        $host = explode(':', (string) $serverHost)[0];
+        $shouldUseHttpProtocol = $this->shouldUseHttpProtocolForHost($host);
+        // $request->_protocol = $shouldUseHttpProtocol ? 'http' : 'https';
+
+        if ($page === 'ojt' && $op === 'api') {
+            define('HANDLER_CLASS', 'OjtPluginApiHandler');
+            $this->plugin->import('OjtPluginApiHandler');
+
+            return true;
+        }
+
+        switch ($page) {
+            case 'ojt':
+                define('HANDLER_CLASS', 'OjtPageHandler');
+                $this->plugin->import('OjtPageHandler');
+
+                return true;
+                break;
+            case $this->plugin->getIndexingPagePath():
+                $enabledPlugins = $this->plugin->getEnabledPluginsSitemap();
+
+                // don't show page for plugins that is not enabled
+                // and don't have getSitemapData method in it
+                if (!$this->plugin->isAddSitemap($enabledPlugins[$op] ?? null)) {
+                    return false;
+                }
+
+                $plugin = $params[1];
+                $op = 'index';
+
+                define('HANDLER_CLASS', IndexingPageHandler::class);
+                IndexingPageHandler::setPlugin($this->plugin, $plugin);
+
+                return true;
+        }
+
+        return false;
+    }
+
+    private function shouldUseHttpProtocolForHost(string $host)
+    {
+        if (in_array($host, ['localhost', '127.0.0.1', '::1'], true)) {
+            return true;
+        }
+
+        if (preg_match('/^(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)/', $host)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    // Show available update on Setting -> Website
+    public function settingsWebsite($hookName, $args)
+    {
+        if (!$this->plugin->getSetting(CONTEXT_SITE, 'isNewVersionAvailable')) {
+            return false;
+        }
+
+        $templateMgr = $args[1];
+        $output = &$args[2];
+
+        $output .= $templateMgr->fetch($this->plugin->getTemplateResource('backend/notif.tpl'));
+
+        // Permit other plugins to continue interacting with this hook
+        return false;
+    }
+
+    public function addIndexingPage($hookName, $args)
+    {
+        return $this->plugin->addIndexingPage($hookName, $args);
+    }
+}

--- a/src/Services/InstallerService.php
+++ b/src/Services/InstallerService.php
@@ -1,0 +1,362 @@
+<?php
+
+namespace Openjournalteam\OjtPlugin\Services;
+
+use GuzzleHttp\Exception\BadResponseException;
+use Exception;
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+class InstallerService
+{
+    private \OjtPlugin $plugin;
+
+    public function __construct(\OjtPlugin $plugin)
+    {
+        $this->plugin = $plugin;
+    }
+
+    public function updatePanel($url)
+    {
+        // Check ziparchive extension
+        if (!class_exists('ZipArchive')) {
+            throw new Exception('Please Install PHP Zip Extension');
+        }
+
+        // Download file
+        $file_name = \Config::getVar('files', 'files_dir') . DIRECTORY_SEPARATOR . 'OJTPanel.zip';
+
+        $resource = \GuzzleHttp\Psr7\Utils::tryFopen($file_name, 'w');
+        $stream = \GuzzleHttp\Psr7\Utils::streamFor($resource);
+        $this->plugin->getHttpClient()->request('GET', $url, ['sink' => $stream]);
+
+        $zip = new \ZipArchive;
+        if (!$zip->open($file_name)) {
+            unlink($file_name);
+            throw new Exception('Failed to Open Files plugin file');
+        }
+
+        $path    = 'plugins/generic';
+        if (!$zip->extractTo($path)) {
+            unlink($file_name);
+            throw new Exception('Failed to Extract Plugin,maybe because of folder permission.');
+        }
+        $zip->close();
+
+        unlink($file_name);
+    }
+
+    public function getPluginDownloadLink($pluginToken, $license = false, $journalUrl)
+    {
+        try {
+            $payload = [
+                'token' => $pluginToken,
+                'license' => $license,
+                'journal_url' => $journalUrl,
+                'ojs_version' => $this->plugin->getJournalVersion()
+            ];
+
+            $request = $this->plugin->getHttpClient(['Content-Type' => 'application/x-www-form-urlencoded',])
+                ->post(
+                    \OjtPlugin::API . '/product/get_download_link',
+                    [
+                        'form_params' => $payload,
+                    ]
+                );
+
+            $response = json_decode((string) $request->getBody(), true);
+
+            if (isset($response['error']) && $response['error']) throw new Exception($response['msg']);
+
+            $result['product'] = $response['data']['download_link'];
+
+            $dependencies = [];
+            foreach ($response['data']['dependencies'] as $dependency) {
+                $data['link'] = $dependency['download_link'];
+                $data['folder'] = $dependency['folder'];
+                $dependencies[] = $data;
+            }
+
+            $result['dependencies'] = $dependencies;
+
+            return $result;
+        } catch (BadResponseException $e) {
+            throw $e;
+        } catch (Exception $e) {
+            throw $e;
+        }
+    }
+
+    /**
+     * Installing plugin to targeted folder.
+     * throw error if there is something wrong
+     * @return bool - true if success.
+     */
+    public function installPlugin($url)
+    {
+        $url = str_replace('https', 'http', $url);
+
+        // Download file
+        $file_name = \Config::getVar('files', 'files_dir') . DIRECTORY_SEPARATOR . 'OJTTemporaryFile.zip';
+        $resource = \GuzzleHttp\Psr7\Utils::tryFopen($file_name, 'w');
+        $stream = \GuzzleHttp\Psr7\Utils::streamFor($resource);
+        $this->plugin->getHttpClient()->request('GET', $url, ['sink' => $stream]);
+        // Extract file
+        if (!class_exists('ZipArchive')) {
+            unlink($file_name);
+            throw new Exception('Please Install PHP Zip Extension');
+        }
+
+        $zip = new \ZipArchive;
+        if (!$zip->open($file_name)) {
+            unlink($file_name);
+            throw new Exception('Failed to Open Files');
+        }
+
+        $path    = $this->plugin->getModulesPath();
+        if (!$zip->extractTo($path)) {
+            unlink($file_name);
+            throw new Exception('Failed to Extract Plugin, because of folder permission.');
+        }
+        $zip->close();
+
+        unlink($file_name);
+
+        return true;
+    }
+
+    /**
+     * Get the base path for staging directory
+     * @return string
+     */
+    public function getStagingBasePath()
+    {
+        return \Config::getVar('files', 'files_dir') . DIRECTORY_SEPARATOR . 'ojt_staging';
+    }
+
+    /**
+     * Install plugin to staging directory first
+     * @param string $url Download URL for the plugin
+     * @return array ['stagingPath' => string, 'pluginFolder' => string]
+     * @throws Exception if installation fails
+     */
+    public function installPluginToStaging($url)
+    {
+        $url = str_replace('https', 'http', $url);
+
+        // Download file
+        $file_name = \Config::getVar('files', 'files_dir') . DIRECTORY_SEPARATOR . 'OJTTemporaryFile_' . uniqid() . '.zip';
+        $resource = \GuzzleHttp\Psr7\Utils::tryFopen($file_name, 'w');
+        $stream = \GuzzleHttp\Psr7\Utils::streamFor($resource);
+        $this->plugin->getHttpClient()->request('GET', $url, ['sink' => $stream]);
+
+        // Extract file
+        if (!class_exists('ZipArchive')) {
+            unlink($file_name);
+            throw new Exception('Please Install PHP Zip Extension');
+        }
+
+        $zip = new \ZipArchive;
+        if (!$zip->open($file_name)) {
+            unlink($file_name);
+            throw new Exception('Failed to Open Files');
+        }
+
+        // Create staging directory
+        $stagingBasePath = $this->getStagingBasePath();
+        if (!is_dir($stagingBasePath)) {
+            if (!mkdir($stagingBasePath, 0755, true)) {
+                unlink($file_name);
+                throw new Exception('Failed to create staging directory');
+            }
+        }
+
+        // Create unique staging path for this installation
+        $stagingPath = $stagingBasePath . DIRECTORY_SEPARATOR . 'staging_' . uniqid();
+        if (!mkdir($stagingPath, 0755, true)) {
+            unlink($file_name);
+            throw new Exception('Failed to create staging subdirectory');
+        }
+
+        if (!$zip->extractTo($stagingPath)) {
+            unlink($file_name);
+            $this->recursiveDelete($stagingPath);
+            throw new Exception('Failed to Extract Plugin to staging, because of folder permission.');
+        }
+
+        // Detect the plugin folder name from extracted contents
+        $extractedFolders = array_diff(scandir($stagingPath), ['.', '..']);
+        if (empty($extractedFolders)) {
+            unlink($file_name);
+            $this->recursiveDelete($stagingPath);
+            throw new Exception('No plugin folder found in extracted archive');
+        }
+
+        $pluginFolder = reset($extractedFolders);
+
+        $zip->close();
+        unlink($file_name);
+
+        return [
+            'stagingPath' => $stagingPath,
+            'pluginFolder' => $pluginFolder
+        ];
+    }
+
+    /**
+     * Move staged plugin to final destination
+     * @param string $stagingPath Path to staging directory
+     * @param string $pluginFolder Plugin folder name
+     * @param bool $isSiteWide Whether plugin is site-wide
+     * @throws Exception if move fails
+     */
+    public function moveStagedPluginToFinal($stagingPath, $pluginFolder, $isSiteWide)
+    {
+        $sourcePath = $stagingPath . DIRECTORY_SEPARATOR . $pluginFolder;
+
+        if ($isSiteWide) {
+            $destinationPath = getcwd() . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR . 'generic' . DIRECTORY_SEPARATOR . $pluginFolder;
+        } else {
+            $this->plugin->createModulesFolder();
+            $destinationPath = getcwd() . DIRECTORY_SEPARATOR . $this->plugin->getModulesPath($pluginFolder);
+        }
+
+        if (!is_dir($sourcePath)) {
+            throw new Exception("Source plugin directory not found in staging: {$sourcePath}");
+        }
+
+        // Remove existing destination if it exists
+        if (is_dir($destinationPath)) {
+            $this->recursiveDelete($destinationPath);
+        }
+
+        // Move the plugin directory
+        if (!rename($sourcePath, $destinationPath)) {
+            throw new Exception("Failed to move plugin from staging to final destination");
+        }
+
+        // Clean up the staging directory
+        if (is_dir($stagingPath) && count(array_diff(scandir($stagingPath), ['.', '..'])) === 0) {
+            rmdir($stagingPath);
+        }
+
+        $location = $isSiteWide ? 'plugins/generic/' : 'modules/';
+        error_log("Plugin '{$pluginFolder}' installed to {$location}");
+    }
+
+    /**
+     * Instantiate a plugin from the modules directory without throwing an exception
+     * @param string $pluginFolder Plugin folder name
+     * @return Plugin|false Plugin instance or false if not found
+     */
+    public function instantiatePluginWithoutThrow($pluginFolder)
+    {
+        $indexFile = $this->plugin->getModulesPath($pluginFolder . DIRECTORY_SEPARATOR . 'index.php');
+        if (!file_exists($indexFile)) {
+            return false;
+        }
+        return @include($indexFile);
+    }
+
+    /**
+     * Instantiate a plugin from the global plugins/generic directory
+     * @param string $pluginFolder Plugin folder name
+     * @return Plugin|false Plugin instance or false if not found
+     */
+    public function instantiatePluginFromGlobalDirectory($pluginFolder)
+    {
+        $indexFile = getcwd() . DIRECTORY_SEPARATOR . 'plugins' . DIRECTORY_SEPARATOR . 'generic' . DIRECTORY_SEPARATOR . $pluginFolder . DIRECTORY_SEPARATOR . 'index.php';
+        if (!file_exists($indexFile)) {
+            return false;
+        }
+        return @include($indexFile);
+    }
+
+    /**
+     * Clean up old staging directories
+     * @param int $hoursOld Delete staging directories older than this many hours
+     */
+    public function cleanupOldStagingDirectories($hoursOld = 24)
+    {
+        $stagingBasePath = $this->getStagingBasePath();
+        if (!is_dir($stagingBasePath)) {
+            return;
+        }
+
+        $cutoffTime = time() - ($hoursOld * 3600);
+        $dirs = array_diff(scandir($stagingBasePath), ['.', '..']);
+
+        foreach ($dirs as $dir) {
+            $dirPath = $stagingBasePath . DIRECTORY_SEPARATOR . $dir;
+            if (is_dir($dirPath) && filemtime($dirPath) < $cutoffTime) {
+                try {
+                    $this->recursiveDelete($dirPath);
+                    error_log("Cleaned up old staging directory: {$dirPath}");
+                } catch (Exception $e) {
+                    error_log("Failed to clean up staging directory: " . $e->getMessage());
+                }
+            }
+        }
+    }
+
+    /**
+     * Removing plugin folder
+     * @return bool - true if success.
+     */
+    public function uninstallPlugin($plugin)
+    {
+        $path = $this->plugin->getModulesPath($plugin->product);
+        if ($plugin->sitewide == true) {
+            $path = 'plugins' . DIRECTORY_SEPARATOR . 'generic' . DIRECTORY_SEPARATOR . $plugin->product;
+        }
+        try {
+            if (!is_dir($path)) {
+                throw new Exception("$plugin->name not Found");
+            }
+            return $this->recursiveDelete($path);
+        } catch (\Throwable $th) {
+            $data['error'] = $th;
+            $data['error_type'] = 'pluginRemoveError';
+
+            // Send notification to discord about the deletion error in uninstallPlugin
+            // $this->plugin->sendDiscordNotification($plugin->name, $data);
+
+            // Re-throw for proper error handling at caller level
+            throw $th;
+        }
+    }
+
+    public function recursiveDelete($dirPath, $deleteParent = true)
+    {
+        if (empty($dirPath) && !is_dir($dirPath)) {
+            return false;
+        }
+
+        $paths = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dirPath, FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::CHILD_FIRST);
+
+        foreach ($paths as $path) {
+            if (!$path->isWritable()) {
+                throw new Exception("Can't remove plugins, please check folder permission for: " . $path->getPathname());
+            };
+        }
+
+        foreach ($paths as $path) {
+            if ($path->isFile()) {
+                if (!unlink($path->getPathname())) {
+                    throw new Exception("Failed to delete file: " . $path->getPathname());
+                }
+            } else {
+                if (!rmdir($path->getPathname())) {
+                    throw new Exception("Failed to remove directory: " . $path->getPathname());
+                }
+            }
+        }
+
+        if ($deleteParent) {
+            rmdir($dirPath);
+        }
+
+        return true;
+    }
+}

--- a/src/Services/JobQueueService.php
+++ b/src/Services/JobQueueService.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace Openjournalteam\OjtPlugin\Services;
+
+use Application;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Queue\Capsule\Manager as Queue;
+use Illuminate\Queue\Worker;
+use Illuminate\Queue\WorkerOptions;
+use Openjournalteam\OjtPlugin\Migrations\MigrationManager;
+use Registry;
+use Throwable;
+
+class JobQueueService
+{
+    const CONNECTION = 'ojtPluginPersistent';
+    const TABLE = 'ojt_plugin_jobs';
+
+    /** @var bool */
+    protected static $queueConnectionBooted = false;
+
+    /** @var \OjtPlugin */
+    protected $plugin;
+
+    public function __construct($plugin)
+    {
+        $this->plugin = $plugin;
+    }
+
+    /**
+     * Dispatch one job into Laravel database queue (connection: persistent).
+     *
+     * @param string $jobType
+     * @param array $payload
+     * @param array $options queue, delaySeconds, contextId
+     * @return mixed Job ID from queue backend.
+     */
+    public function dispatch($jobType, $payload = [], $options = [])
+    {
+        if (!$jobType) {
+            return null;
+        }
+
+        $this->bootQueueConnection();
+
+        $queueName = (string) ($options['queue'] ?? 'default');
+        $delaySeconds = (int) ($options['delaySeconds'] ?? 0);
+        $contextId = $this->resolveContextId($options, $payload);
+        $data = [
+            'jobType' => (string) $jobType,
+            'payload' => is_array($payload) ? $payload : [],
+            'contextId' => $contextId ?: null,
+            'maxAttempts' => isset($options['maxAttempts']) ? max(1, (int) $options['maxAttempts']) : null,
+            'enqueuedAt' => time(),
+        ];
+
+        $job = 'OjtWorkerBeeJobHandler@fire';
+        try {
+            if ($delaySeconds > 0) {
+                $jobId = Queue::later($delaySeconds, $job, $data, $queueName, self::CONNECTION);
+                $this->persistContextId($jobId, $contextId);
+                return $jobId;
+            }
+
+            $jobId = Queue::push($job, $data, $queueName, self::CONNECTION);
+            $this->persistContextId($jobId, $contextId);
+            return $jobId;
+        } catch (Throwable $e) {
+            error_log('OjtWorkerBee dispatch failed: ' . $e->getMessage());
+            return null;
+        }
+    }
+
+    public function isEnabledForRuntime()
+    {
+        $plugin = $this->plugin;
+
+        if ($plugin->getEnabled()) {
+            return true;
+        }
+
+        $pluginName = strtolower_codesafe($plugin->getName());
+        $pluginSettingsDao = \DAORegistry::getDAO('PluginSettingsDAO');
+        $result = $pluginSettingsDao->retrieve(
+            'SELECT setting_value FROM plugin_settings WHERE plugin_name = ? AND setting_name = ? AND setting_value IN (?, ?, ?, ?) LIMIT 1',
+            [
+                $pluginName,
+                'enabled',
+                '1',
+                'true',
+                'on',
+                'yes',
+            ]
+        );
+
+        return (bool) $result->current();
+    }
+
+    /**
+     * Run exactly one queued job.
+     *
+     * @param string $queueName
+     * @param array $options sleep, tries, timeout
+     * @return int
+     */
+    public function runNext($queueName = 'default', $options = [])
+    {
+        $this->bootQueueConnection();
+        $worker = $this->makeWorker();
+        $workerOptions = $this->makeWorkerOptions($options, false);
+        $worker->runNextJob(self::CONNECTION, $queueName, $workerOptions);
+        return 1;
+    }
+
+    /**
+     * Run a daemon worker loop.
+     *
+     * @param string $queueName
+     * @param array $options sleep, tries, timeout, stopWhenEmpty
+     * @return void
+     */
+    public function daemon($queueName = 'default', $options = [])
+    {
+        $this->bootQueueConnection();
+        $worker = $this->makeWorker();
+        $workerOptions = $this->makeWorkerOptions($options, (bool) ($options['stopWhenEmpty'] ?? false));
+        $worker->daemon(self::CONNECTION, $queueName, $workerOptions);
+    }
+
+    /**
+     * Get queue stats from jobs table.
+     */
+    public function stats($queueName = 'default')
+    {
+        MigrationManager::make($this)->runMigrations();
+        $query = Capsule::table(self::TABLE)->where('queue', '=', (string) $queueName);
+
+        return [
+            'pending' => (int) (clone $query)->whereNull('reserved_at')->count(),
+            'running' => (int) (clone $query)->whereNotNull('reserved_at')->count(),
+            'total' => (int) (clone $query)->count(),
+        ];
+    }
+
+    protected function makeWorker()
+    {
+        $laravelContainer = Registry::get('laravelContainer');
+
+        return new Worker(
+            $laravelContainer['queue'],
+            $laravelContainer['events'],
+            $laravelContainer['exception.handler'],
+            function () {
+                return false;
+            }
+        );
+    }
+
+    protected function bootQueueConnection()
+    {
+        if (self::$queueConnectionBooted) {
+            return;
+        }
+
+        MigrationManager::make($this)->runMigrations();
+
+        // Register runtime queue connection via container config.
+        $laravelContainer = Registry::get('laravelContainer');
+        if (isset($laravelContainer['config'])) {
+            $laravelContainer['config']['queue.connections.' . self::CONNECTION] = [
+                'driver' => 'database',
+                'table' => self::TABLE,
+                'connection' => 'default',
+                'queue' => 'default',
+            ];
+        } else {
+            $laravelContainer['config'] = [
+                'queue.connections.' . self::CONNECTION => [
+                    'driver' => 'database',
+                    'table' => self::TABLE,
+                    'connection' => 'default',
+                    'queue' => 'default',
+                ],
+            ];
+        }
+
+        self::$queueConnectionBooted = true;
+    }
+
+    protected function makeWorkerOptions($options, $stopWhenEmpty)
+    {
+        $sleep = isset($options['sleep']) ? max(0, (int) $options['sleep']) : 3;
+        $tries = isset($options['tries']) ? max(1, (int) $options['tries']) : 3;
+        $timeout = isset($options['timeout']) ? max(1, (int) $options['timeout']) : 60;
+        $memory = isset($options['memory']) ? max(64, (int) $options['memory']) : 128;
+
+        return new WorkerOptions(
+            0,
+            $memory,
+            $timeout,
+            $sleep,
+            $tries,
+            false,
+            $stopWhenEmpty
+        );
+    }
+
+    /**
+     * Resolve journal/context id from options or payload.
+     *
+     * @param array $options
+     * @param array $payload
+     * @return int|null
+     */
+    protected function resolveContextId($options, $payload)
+    {
+        if (isset($options['contextId']) && (int) $options['contextId'] > 0) {
+            return (int) $options['contextId'];
+        }
+
+        if (isset($payload['contextId']) && (int) $payload['contextId'] > 0) {
+            return (int) $payload['contextId'];
+        }
+
+        if (isset($payload['journalId']) && (int) $payload['journalId'] > 0) {
+            return (int) $payload['journalId'];
+        }
+
+        $request = Application::get() ? Application::get()->getRequest() : null;
+        $context = $request ? $request->getContext() : null;
+        if ($context && (int) $context->getId() > 0) {
+            return (int) $context->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * Store context id in dedicated column for fast filtering.
+     *
+     * @param mixed $jobId
+     * @param int|null $contextId
+     * @return void
+     */
+    protected function persistContextId($jobId, $contextId)
+    {
+        if (!$jobId) {
+            return;
+        }
+
+        if (!$contextId || (int) $contextId <= 0) {
+            return;
+        }
+
+        try {
+            Capsule::table(self::TABLE)
+                ->where('id', '=', (int) $jobId)
+                ->update(['context_id' => (int) $contextId]);
+        } catch (Throwable $e) {
+            error_log('OjtWorkerBee context_id update failed for job ' . (int) $jobId . ': ' . $e->getMessage());
+        }
+    }
+}

--- a/src/Services/JobQueueService.php
+++ b/src/Services/JobQueueService.php
@@ -14,7 +14,8 @@ use Throwable;
 class JobQueueService
 {
     const CONNECTION = 'ojtPluginPersistent';
-    const TABLE = 'ojt_plugin_jobs';
+    const JOBS_TABLE = 'ojt_jobs';
+    const FAILED_JOBS_TABLE = 'ojt_failed_jobs';
 
     /** @var bool */
     protected static $queueConnectionBooted = false;
@@ -54,7 +55,7 @@ class JobQueueService
             'enqueuedAt' => time(),
         ];
 
-        $job = 'OjtWorkerBeeJobHandler@fire';
+        $job = 'Openjournalteam\\OjtPlugin\\Jobs\\Handlers\\JobHandler@fire';
         try {
             if ($delaySeconds > 0) {
                 $jobId = Queue::later($delaySeconds, $job, $data, $queueName, self::CONNECTION);
@@ -132,8 +133,8 @@ class JobQueueService
      */
     public function stats($queueName = 'default')
     {
-        MigrationManager::make($this)->runMigrations();
-        $query = Capsule::table(self::TABLE)->where('queue', '=', (string) $queueName);
+        MigrationManager::make($this->plugin)->runMigrations();
+        $query = Capsule::table(self::JOBS_TABLE)->where('queue', '=', (string) $queueName);
 
         return [
             'pending' => (int) (clone $query)->whereNull('reserved_at')->count(),
@@ -162,14 +163,14 @@ class JobQueueService
             return;
         }
 
-        MigrationManager::make($this)->runMigrations();
+        MigrationManager::make($this->plugin)->runMigrations();
 
         // Register runtime queue connection via container config.
         $laravelContainer = Registry::get('laravelContainer');
         if (isset($laravelContainer['config'])) {
             $laravelContainer['config']['queue.connections.' . self::CONNECTION] = [
                 'driver' => 'database',
-                'table' => self::TABLE,
+                'table' => self::JOBS_TABLE,
                 'connection' => 'default',
                 'queue' => 'default',
             ];
@@ -177,7 +178,7 @@ class JobQueueService
             $laravelContainer['config'] = [
                 'queue.connections.' . self::CONNECTION => [
                     'driver' => 'database',
-                    'table' => self::TABLE,
+                    'table' => self::JOBS_TABLE,
                     'connection' => 'default',
                     'queue' => 'default',
                 ],
@@ -253,7 +254,7 @@ class JobQueueService
         }
 
         try {
-            Capsule::table(self::TABLE)
+            Capsule::table(self::JOBS_TABLE)
                 ->where('id', '=', (int) $jobId)
                 ->update(['context_id' => (int) $contextId]);
         } catch (Throwable $e) {

--- a/src/Services/LoggingService.php
+++ b/src/Services/LoggingService.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Openjournalteam\OjtPlugin\Services;
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Monolog\Utils;
+use Openjournalteam\OjtPlugin\Classes\ServiceHandler;
+use Psr\Log\LogLevel;
+use Throwable;
+
+class LoggingService
+{
+    private \OjtPlugin $plugin;
+
+    public function __construct(\OjtPlugin $plugin)
+    {
+        $this->plugin = $plugin;
+    }
+
+    public function isAllowSendLog($hour = 4)
+    {
+        $now = time();
+        $lastSendLogTime = $this->plugin->getSetting(CONTEXT_SITE, 'lastSendLogTime');
+        if ($lastSendLogTime === null) {
+            return true;
+        }
+
+        $diff = $now - $lastSendLogTime;
+        $diffInHour = round($diff / (60 * 60));
+        return $diffInHour >= $hour;
+    }
+
+    public static function getErrorLogFile()
+    {
+        return \Config::getVar('files', 'files_dir') . DIRECTORY_SEPARATOR . 'ojtPlugin' . DIRECTORY_SEPARATOR . 'error.log';
+    }
+
+    public function deleteLogFile(): bool
+    {
+        $errorLogFile = $this->getErrorLogFile();
+        if (!is_file($errorLogFile)) return false;
+
+        return unlink($errorLogFile);
+    }
+
+    public function isTimeToDeleteLog($days = 2)
+    {
+        $errorLogFile = $this->getErrorLogFile();
+
+        if (!is_file($errorLogFile)) return false;
+
+        $dateCreatedFile = filemtime($errorLogFile);
+
+        $now = time();
+        $datediff = $now - $dateCreatedFile;
+        $diffInDays = round($datediff / (60 * 60 * 24));
+
+        return $diffInDays > $days;
+    }
+
+    public function setLogger()
+    {
+        // Jangan simpan log error ketika setting ini didisable
+        if (!$this->isDiagnosticEnabled()) return;
+
+        $logger = new Logger('OJTLog');
+        $logger->pushHandler(new ServiceHandler(Logger::ERROR));
+        $logger->pushHandler(new StreamHandler($this->getErrorLogFile(), Logger::ERROR));
+
+        set_exception_handler(function (Throwable $e) use ($logger): void {
+            if ($this->isTimeToDeleteLog()) {
+                $this->deleteLogFile();
+            };
+
+            if (ojt_str_contains($e->getFile(), 'ojtPlugin')) {
+                $logger->log(
+                    LogLevel::ERROR,
+                    sprintf('Uncaught Exception %s: "%s" at %s line %s', Utils::getClass($e), $e->getMessage(), $e->getFile(), $e->getLine()),
+                    ['exception' => $e]
+                );
+            }
+
+            throw $e;
+        });
+
+        set_error_handler(function (int $code, string $message, string $file = '', int $line = 0, ?array $context = []) use ($logger): bool {
+            if ($code !== E_ERROR) return false;
+
+            if ($this->isTimeToDeleteLog()) {
+                $this->deleteLogFile();
+            };
+
+            $logger->log(LogLevel::CRITICAL, 'E_ERROR: ' . $message, ['code' => $code, 'message' => $message, 'file' => $file, 'line' => $line]);
+            return false;
+        });
+    }
+
+    public function isDiagnosticEnabled()
+    {
+        return $this->plugin->getSetting(CONTEXT_SITE, 'enable_diagnostic') ?? true;
+    }
+}

--- a/src/Services/ModulesService.php
+++ b/src/Services/ModulesService.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Openjournalteam\OjtPlugin\Services;
+
+class ModulesService
+{
+    private \OjtPlugin $plugin;
+
+    public function __construct(\OjtPlugin $plugin)
+    {
+        $this->plugin = $plugin;
+    }
+
+    public function getModulesPath($path = '')
+    {
+        return $this->plugin->getPluginPath() . DIRECTORY_SEPARATOR . 'modules' . DIRECTORY_SEPARATOR . $path;
+    }
+
+    public function createModulesFolder()
+    {
+        if (is_dir(getcwd() . DIRECTORY_SEPARATOR . $this->getModulesPath())) {
+            return;
+        }
+
+        mkdir(getcwd() . DIRECTORY_SEPARATOR . $this->getModulesPath());
+    }
+
+    public function registerModules()
+    {
+        $modulesFolder = $this->getDirs($this->getModulesPath());
+
+        import('lib.pkp.classes.site.VersionCheck');
+
+        $plugins = [];
+        $fileManager = new \FileManager();
+        foreach ($modulesFolder as $key => $moduleFolder) {
+            $versionFile = $this->getModulesPath($moduleFolder  . DIRECTORY_SEPARATOR . "version.xml");
+            $indexFile = $this->getModulesPath(DIRECTORY_SEPARATOR . $moduleFolder . DIRECTORY_SEPARATOR . "index.php");
+            if (
+                !$fileManager->fileExists($versionFile) ||
+                !$fileManager->fileExists($indexFile)
+            ) {
+                continue;
+            }
+
+            $plugin         = include($indexFile);
+            if (!$plugin && $plugin instanceof \Plugin) {
+                continue;
+            }
+
+            $version        = \VersionCheck::getValidPluginVersionInfo($versionFile);
+
+            $categoryPlugin = explode('.', $version->getData('productType'))[1];
+            $categoryDir    = $this->getModulesPath();
+            $pluginDir = str_replace('\\', '/', $categoryDir .  $moduleFolder);
+
+            \PluginRegistry::register($categoryPlugin, $plugin, $pluginDir);
+
+            if ($plugin instanceof \ThemePlugin) {
+                $plugin->init();
+            }
+
+            $data                = $version->getAllData();
+            $data['version']     = $version->getVersionString();
+            $data['name']        = $plugin->getDisplayName();
+            $data['className']   = $plugin->getName();
+            $data['description'] = $plugin->getDescription();
+            $data['enabled']     = $plugin->getEnabled();
+
+            if (method_exists($plugin, 'getCanEnable') && !$plugin->getCanEnable()) {
+                $data['isAuthorized']   = $plugin->getCanEnable();
+            } else {
+                $data['isAuthorized']   = $this->plugin->getCanEnable();
+            }
+
+            $data['open']        = false;
+            $data['icon']        = method_exists($plugin, 'getPageIcon') ? $plugin->getPageIcon() : $this->plugin->getDefaultPluginIcon();
+            $data['documentation'] = method_exists($plugin, 'getDocumentation') ? $plugin->getDocumentation() : null;
+            $data['page']        = method_exists($plugin, 'getPage') ? $plugin->getPage() : null;
+            $data['sitemapData'] = method_exists($plugin, 'getSitemapData') ? $plugin->getSitemapData() : null;
+            $data['canDelete']   = method_exists($plugin, 'getCanDelete') ? $plugin->getCanDelete() : true;
+
+            $plugins[] = $data;
+        }
+
+        $this->plugin->registeredModule = $plugins;
+
+        return $plugins;
+    }
+
+    public function getRegisteredModules()
+    {
+        if (!$this->plugin->registeredModule) {
+            return $this->registerModules();
+        }
+
+        return $this->plugin->registeredModule;
+    }
+
+    public function getDirs($path, $recursive = false, array $filtered = [])
+    {
+        $this->createModulesFolder();
+
+        if (!is_dir($path)) {
+            throw new \RuntimeException("$path does not exist.");
+        }
+
+        $filtered += ['.', '..', '.git', 'pluginTemplate'];
+
+        $dirs = [];
+        $d = dir($path);
+
+        while (($entry = $d->read()) !== false) {
+            if (is_dir("$path/$entry") && !in_array($entry, $filtered)) {
+                $dirs[] = $entry;
+
+                if ($recursive) {
+                    $newDirs = $this->getDirs("$path/$entry");
+                    foreach ($newDirs as $newDir) {
+                        $dirs[] = "$entry/$newDir";
+                    }
+                }
+            }
+        }
+        sort($dirs);
+
+        return $dirs;
+    }
+}

--- a/tools/worker.php
+++ b/tools/worker.php
@@ -1,0 +1,8 @@
+<?php
+
+use Openjournalteam\OjtPlugin\Jobs\WorkerTool;
+
+require(dirname(__FILE__) . '/../../../../../../tools/bootstrap.inc.php');
+
+$tool = new WorkerTool(isset($argv) ? $argv : []);
+$tool->execute();

--- a/tools/worker.php
+++ b/tools/worker.php
@@ -2,7 +2,8 @@
 
 use Openjournalteam\OjtPlugin\Jobs\WorkerTool;
 
-require(dirname(__FILE__) . '/../../../../../../tools/bootstrap.inc.php');
+require(dirname(__FILE__) . '/../../../../tools/bootstrap.inc.php');
+require(dirname(__FILE__) . '/../vendor/autoload.php');
 
 $tool = new WorkerTool(isset($argv) ? $argv : []);
 $tool->execute();

--- a/version.xml
+++ b/version.xml
@@ -5,8 +5,8 @@
 <version>
 	<application>ojtPlugin</application>
 	<type>plugins.generic</type>
-	<release>2.1.3.3</release>
-	<date>2026-02-04</date>
+	<release>2.2.0.0</release>
+	<date>2026-03-30</date>
 	<lazy-load>0</lazy-load>
 	<class>OjtPlugin</class>
 </version>


### PR DESCRIPTION
## Description

This PR introduces the full OJT Jobs Ecosystem : 

## Scope

- Adds shared job registry: OjtJobs
- Adds base contract + helper: JobInterface, BaseJob
- Adds central queue handler: JobHandler
- Adds worker CLI runtime: tools/worker.php, WorkerTool
- Adds queue service + runtime checks: JobQueueService
- Adds URL resolver support for runtime jobs: JobUrlResolver
- Adds failure lifecycle hooks and failed-job persistence
- Integrates ecosystem with existing OJT plugin flow

## How to use (quick)

- Register jobs in plugin register():
  `OjtJobs::register($this, [new YourJob($this)])`
- Dispatch:
  `OjtJobs::dispatch($this, 'yourPlugin.jobType', $payload, $options)`
- Run worker:
  `php plugins/generic/ojtPlugin/tools/worker.php --queue=default`
  
## Notes

- Supports delayed jobs, queue selection, and max attempts
- Failed jobs are stored in ojt_failed_jobs
- Lifecycle hooks available:
  `OjtPlugin::beforeProcessJob`, `OjtPlugin::processJob`, `OjtPlugin::afterProcessJob`, `OjtPlugin::jobFailed`